### PR TITLE
Setup CICD with Google Cloud Build

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Follow these [instructions](https://hatch.pypa.io/latest/install/) to install it
 
 ```
 # Run all tests
-hatch run tests
+hatch run test
 
 # Run a single test file
-hatch run tests tests/test_<SOME_FILE>.py
+hatch run test tests/test_<SOME_FILE>.py
 ```
 
 ### Lint / Format

--- a/tools/cicd/Dockerfile
+++ b/tools/cicd/Dockerfile
@@ -1,0 +1,8 @@
+# This Docker image is a modified version of the python image that
+# includes [hatch](https://hatch.pypa.io/latest/)
+
+FROM python:3.9.18
+
+RUN python -m pip install hatch
+
+ENTRYPOINT ["hatch"]

--- a/tools/cicd/cloudbuild.yaml
+++ b/tools/cicd/cloudbuild.yaml
@@ -1,0 +1,39 @@
+steps:
+
+# Import builder if exists.
+# Note: the reason to use bash is to be able to return an exit code 0 even if
+# the docker image doesn't exist yet.
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    docker pull gcr.io/$PROJECT_ID/hatch || exit 0
+
+# Build a modified version of the python image that includes hatch.
+# Use the previous built image as cache.
+- name: 'gcr.io/cloud-builders/docker'
+  dir: 'tools/cicd'
+  args:
+  - build
+  - -f
+  - Dockerfile
+  - -t
+  - gcr.io/$PROJECT_ID/hatch
+  - --cache-from
+  - gcr.io/$PROJECT_ID/hatch
+  - .
+
+- name: gcr.io/$PROJECT_ID/hatch
+  id: tests
+  args:
+  - run
+  - test
+
+- name: gcr.io/$PROJECT_ID/hatch
+  id: lint
+  args:
+  - run
+  - lint:all
+
+images: ['gcr.io/$PROJECT_ID/hatch']


### PR DESCRIPTION
In order to use the [hatch tool](https://hatch.pypa.io/latest/), we create a docker image with it.

This "build" only runs tests and lint for now.

Next: 
- setup GCB triggers for the main branch and for PRs

http://b/305922956