### PR TITLE
Fix lint error: missing type for the implementations

### DIFF
--- a/src/kagglehub/registry.py
+++ b/src/kagglehub/registry.py
@@ -1,3 +1,6 @@
+from typing import Callable, List
+
+
 class MultiImplRegistry:
     """Utility class to inject multiple implementations of class.
 
@@ -8,9 +11,9 @@ class MultiImplRegistry:
 
     def __init__(self, name: str):
         self._name = name
-        self._impls = []
+        self._impls: List[Callable] = []
 
-    def add_implementation(self, impl):
+    def add_implementation(self, impl: Callable):
         self._impls += [impl]
 
     def __call__(self, *args, **kwargs):


### PR DESCRIPTION
I'm also using this PR to test the GCB Trigger integration, as I realized the build [failed](https://github.com/Kaggle/kagglehub/commit/06217d2700bc60e76e504a3fd896bc38ecc93dae) on the `main` branch.