### PR TITLE
Implement cache for downloaded models.

### DIFF
--- a/src/kagglehub/__init__.py
+++ b/src/kagglehub/__init__.py
@@ -1,7 +1,8 @@
 __version__ = "0.0.1a0"
 
+from kagglehub import http_resolver, registry
 from kagglehub.auth import login
-from kagglehub.config import _install_resolvers
 from kagglehub.models import model_download, model_upload
 
-_install_resolvers()
+registry.resolver.add_implementation(http_resolver.HttpResolver())
+# TODO(b/305947763): Implement Kaggle Cache resolver.

--- a/src/kagglehub/cache.py
+++ b/src/kagglehub/cache.py
@@ -1,0 +1,47 @@
+import os
+from typing import Optional, Union
+
+from kagglehub.config import get_cache_folder
+from kagglehub.handle import ModelHandle
+
+MODELS_CACHE_SUBFOLDER = "models"
+
+
+def load_from_cache(
+    handle: Union[ModelHandle], path: Optional[str] = None, cache_dir: Optional[str] = None
+) -> Optional[str]:
+    """Return path for the requested resource from the cache.
+
+    Args:
+        handle: Resource handle
+        path: Optional path to a file within the bundle.
+        cache_dir: Optional cache directory to use. Defaults to ~/.cache/kagglehub.
+
+    Returns:
+        A string representing the path to the requested resource in the cache or None on cache miss.
+    """
+    full_path = get_cached_path(handle, path, cache_dir)
+    return full_path if os.path.exists(full_path) else None
+
+
+def get_cached_path(handle: Union[ModelHandle], path: Optional[str] = None, cache_dir: Optional[str] = None) -> str:
+    # Can extend to add support for other resources like DatasetHandle.
+    if isinstance(handle, ModelHandle):
+        return _get_model_path(handle, path, cache_dir)
+    else:
+        msg = "Invalid handle"
+        raise ValueError(msg)
+
+
+def _get_model_path(handle: ModelHandle, path: Optional[str] = None, cache_dir: Optional[str] = None):
+    base_path = os.path.join(
+        cache_dir if cache_dir else get_cache_folder(),
+        MODELS_CACHE_SUBFOLDER,
+        handle.owner,
+        handle.model,
+        handle.framework,
+        handle.variation,
+        str(handle.version),
+    )
+
+    return os.path.join(base_path, path) if path else base_path

--- a/src/kagglehub/cache.py
+++ b/src/kagglehub/cache.py
@@ -7,35 +7,32 @@ from kagglehub.handle import ModelHandle
 MODELS_CACHE_SUBFOLDER = "models"
 
 
-def load_from_cache(
-    handle: Union[ModelHandle], path: Optional[str] = None, cache_dir: Optional[str] = None
-) -> Optional[str]:
+def load_from_cache(handle: Union[ModelHandle], path: Optional[str] = None) -> Optional[str]:
     """Return path for the requested resource from the cache.
 
     Args:
         handle: Resource handle
         path: Optional path to a file within the bundle.
-        cache_dir: Optional cache directory to use. Defaults to ~/.cache/kagglehub.
 
     Returns:
         A string representing the path to the requested resource in the cache or None on cache miss.
     """
-    full_path = get_cached_path(handle, path, cache_dir)
+    full_path = get_cached_path(handle, path)
     return full_path if os.path.exists(full_path) else None
 
 
-def get_cached_path(handle: Union[ModelHandle], path: Optional[str] = None, cache_dir: Optional[str] = None) -> str:
+def get_cached_path(handle: Union[ModelHandle], path: Optional[str] = None) -> str:
     # Can extend to add support for other resources like DatasetHandle.
     if isinstance(handle, ModelHandle):
-        return _get_model_path(handle, path, cache_dir)
+        return _get_model_path(handle, path)
     else:
         msg = "Invalid handle"
         raise ValueError(msg)
 
 
-def _get_model_path(handle: ModelHandle, path: Optional[str] = None, cache_dir: Optional[str] = None):
+def _get_model_path(handle: ModelHandle, path: Optional[str] = None):
     base_path = os.path.join(
-        cache_dir if cache_dir else get_cache_folder(),
+        get_cache_folder(),
         MODELS_CACHE_SUBFOLDER,
         handle.owner,
         handle.model,

--- a/src/kagglehub/config.py
+++ b/src/kagglehub/config.py
@@ -1,6 +1,11 @@
-from kagglehub import http_resolver, registry
+import os
+from pathlib import Path
+
+DEFAULT_CACHE_FOLDER = os.path.join(Path.home(), ".cache", "kagglehub")
+CACHE_FOLDER_ENV_VAR_NAME = "KAGGLEHUB_CACHE"
 
 
-def _install_resolvers():
-    registry.resolver.add_implementation(http_resolver.HttpResolver())
-    # TODO(b/305947763): Implement Kaggle Cache resolver.
+def get_cache_folder():
+    if CACHE_FOLDER_ENV_VAR_NAME in os.environ:
+        return os.environ[CACHE_FOLDER_ENV_VAR_NAME]
+    return DEFAULT_CACHE_FOLDER

--- a/src/kagglehub/handle.py
+++ b/src/kagglehub/handle.py
@@ -1,0 +1,44 @@
+"""Functions to parse resource handles."""
+from dataclasses import dataclass
+from typing import Optional
+
+NUM_VERSIONED_MODEL_PARTS = 5  # e.g.: <owner>/<model>/<framework>/<variation>/<version>
+NUM_UNVERSIONED_MODEL_PARTS = 4  # e.g.: <owner>/<model>/<framework>/<variation>
+
+
+@dataclass
+class ModelHandle:
+    owner: str
+    model: str
+    framework: str
+    variation: str
+    version: int
+
+
+def parse_model_handle(handle: str) -> Optional[ModelHandle]:
+    parts = handle.split("/")
+
+    if len(parts) == NUM_VERSIONED_MODEL_PARTS:
+        # Versioned handle
+        # e.g.: <owner>/<model>/<framework>/<variation>/<version>
+        try:
+            version = int(parts[4])
+        except ValueError as err:
+            msg = f"Invalid version number: {parts[4]}"
+            raise ValueError(msg) from err
+
+        return ModelHandle(
+            owner=parts[0],
+            model=parts[1],
+            framework=parts[2],
+            variation=parts[3],
+            version=version,
+        )
+    elif len(parts) == NUM_UNVERSIONED_MODEL_PARTS:
+        # Unversioned handle
+        # e.g.: <owner>/<model>/<framework>/<variation>
+        msg = "Unversioned model handle is not yet supported"
+        raise NotImplementedError(msg)
+
+    msg = f"Invalid model handle: {handle}"
+    raise ValueError(msg)

--- a/src/kagglehub/handle.py
+++ b/src/kagglehub/handle.py
@@ -1,6 +1,5 @@
 """Functions to parse resource handles."""
 from dataclasses import dataclass
-from typing import Optional
 
 NUM_VERSIONED_MODEL_PARTS = 5  # e.g.: <owner>/<model>/<framework>/<variation>/<version>
 NUM_UNVERSIONED_MODEL_PARTS = 4  # e.g.: <owner>/<model>/<framework>/<variation>
@@ -15,7 +14,7 @@ class ModelHandle:
     version: int
 
 
-def parse_model_handle(handle: str) -> Optional[ModelHandle]:
+def parse_model_handle(handle: str) -> ModelHandle:
     parts = handle.split("/")
 
     if len(parts) == NUM_VERSIONED_MODEL_PARTS:

--- a/src/kagglehub/http_resolver.py
+++ b/src/kagglehub/http_resolver.py
@@ -10,9 +10,9 @@ class HttpResolver(Resolver):
         # Downloading files over HTTP is supported in all environments for all handles / path.
         return True
 
-    def __call__(self, handle: str, path: Optional[str] = None, cache_dir: Optional[str] = None):
+    def __call__(self, handle: str, path: Optional[str] = None):
         model_handle = parse_model_handle(handle)
-        model_path = load_from_cache(model_handle, path, cache_dir)
+        model_path = load_from_cache(model_handle, path)
         if model_path:
             return model_path  # Already cached
 

--- a/src/kagglehub/http_resolver.py
+++ b/src/kagglehub/http_resolver.py
@@ -1,13 +1,20 @@
 from typing import Optional
 
-from kagglehub import resolver
+from kagglehub.cache import load_from_cache
+from kagglehub.handle import parse_model_handle
+from kagglehub.resolver import Resolver
 
 
-class HttpResolver(resolver.Resolver):
+class HttpResolver(Resolver):
     def is_supported(self, *_):
         # Downloading files over HTTP is supported in all environments for all handles / path.
         return True
 
-    def __call__(self, handle: str, path: Optional[str] = None):
-        # TODO(b/305947384): Parse handle, call models download API & implement resumable download.
+    def __call__(self, handle: str, path: Optional[str] = None, cache_dir: Optional[str] = None):
+        model_handle = parse_model_handle(handle)
+        model_path = load_from_cache(model_handle, path, cache_dir)
+        if model_path:
+            return model_path  # Already cached
+
+        # TODO(b/305947384): Call models download API & implement resumable download.
         raise NotImplementedError()

--- a/src/kagglehub/models.py
+++ b/src/kagglehub/models.py
@@ -3,18 +3,17 @@ from typing import Optional
 from kagglehub import registry
 
 
-def model_download(handle: str, path: Optional[str] = None, cache_dir: Optional[str] = None):
+def model_download(handle: str, path: Optional[str] = None):
     """Download model files.
 
     Args:
         handle: (string) the model handle.
         path: (string) Optional path to a file within the model bundle.
-        cache_dir: (string) Optional cache directory to use. Defaults to ~/.cache/kagglehub.
 
     Returns:
         A string representing the path to the requested model files.
     """
-    return registry.resolver(handle, path, cache_dir)
+    return registry.resolver(handle, path)
 
 
 def model_upload():

--- a/src/kagglehub/models.py
+++ b/src/kagglehub/models.py
@@ -3,17 +3,18 @@ from typing import Optional
 from kagglehub import registry
 
 
-def model_download(handle: str, path: Optional[str] = None):
+def model_download(handle: str, path: Optional[str] = None, cache_dir: Optional[str] = None):
     """Download model files.
 
     Args:
         handle: (string) the model handle.
-        path: (string) Optional path to files within the model bundle.
+        path: (string) Optional path to a file within the model bundle.
+        cache_dir: (string) Optional cache directory to use. Defaults to ~/.cache/kagglehub.
 
     Returns:
         A string representing the path to the requested model files.
     """
-    return registry.resolver(handle, path)
+    return registry.resolver(handle, path, cache_dir)
 
 
 def model_upload():

--- a/src/kagglehub/resolver.py
+++ b/src/kagglehub/resolver.py
@@ -8,13 +8,12 @@ class Resolver:
     __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
-    def __call__(self, handle: str, path: Optional[str] = None, cache_dir: Optional[str] = None) -> str:
+    def __call__(self, handle: str, path: Optional[str] = None) -> str:
         """Resolves a handle into a path with the requested model files.
 
         Args:
             handle: (string) the model handle to resolve.
             path: (string) Optional path to a file within the model bundle.
-            cache_dir: (string) Optional cache directory to use. Defaults to ~/.cache/kagglehub.
 
 
         Returns:

--- a/src/kagglehub/resolver.py
+++ b/src/kagglehub/resolver.py
@@ -8,11 +8,14 @@ class Resolver:
     __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
-    def __call__(self, handle: str, path: Optional[str] = None) -> str:
+    def __call__(self, handle: str, path: Optional[str] = None, cache_dir: Optional[str] = None) -> str:
         """Resolves a handle into a path with the requested model files.
 
         Args:
             handle: (string) the model handle to resolve.
+            path: (string) Optional path to a file within the model bundle.
+            cache_dir: (string) Optional cache directory to use. Defaults to ~/.cache/kagglehub.
+
 
         Returns:
             A string representing the path

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,62 @@
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from kagglehub.cache import MODELS_CACHE_SUBFOLDER, get_cached_path, load_from_cache
+from kagglehub.handle import ModelHandle
+
+TEST_MODEL_HANDLE = ModelHandle(
+    owner="google",
+    model="bert",
+    framework="tensorFlow2",
+    variation="answer-equivalence-bem",
+    version=2,
+)
+
+
+class TestCache(unittest.TestCase):
+    def test_load_from_cache_miss(self):
+        ModelHandle(
+            owner="google",
+            model="bert",
+            framework="tensorFlow2",
+            variation="answer-equivalence-bem",
+            version=2,
+        )
+        self.assertEqual(None, load_from_cache(TEST_MODEL_HANDLE))
+
+    def test_load_from_cache_with_path_miss(self):
+        self.assertEqual(None, load_from_cache(TEST_MODEL_HANDLE, "foo.txt"))
+
+    def test_cache_hit(self):
+        with TemporaryDirectory() as d:
+            cache_path = get_cached_path(TEST_MODEL_HANDLE, cache_dir=d)
+            os.makedirs(cache_path)
+
+            path = load_from_cache(TEST_MODEL_HANDLE, cache_dir=d)
+
+            self.assertEqual(
+                os.path.join(d, MODELS_CACHE_SUBFOLDER, "google", "bert", "tensorFlow2", "answer-equivalence-bem", "2"),
+                path,
+            )
+
+    def test_cache_hit_with_path(self):
+        with TemporaryDirectory() as d:
+            cache_path = get_cached_path(TEST_MODEL_HANDLE, cache_dir=d)
+
+            os.makedirs(cache_path)
+            Path.touch(os.path.join(cache_path, "foo.txt"))  # Create file
+
+            path = load_from_cache(TEST_MODEL_HANDLE, path="foo.txt", cache_dir=d)
+
+            self.assertEqual(
+                os.path.join(
+                    d, MODELS_CACHE_SUBFOLDER, "google", "bert", "tensorFlow2", "answer-equivalence-bem", "2", "foo.txt"
+                ),
+                path,
+            )
+
+    def test_load_from_cache_invalid_handle(self):
+        with self.assertRaises(ValueError):
+            load_from_cache("invalid_handle")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -2,8 +2,10 @@ import os
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest import mock
 
 from kagglehub.cache import MODELS_CACHE_SUBFOLDER, get_cached_path, load_from_cache
+from kagglehub.config import CACHE_FOLDER_ENV_VAR_NAME
 from kagglehub.handle import ModelHandle
 
 TEST_MODEL_HANDLE = ModelHandle(
@@ -31,31 +33,42 @@ class TestCache(unittest.TestCase):
 
     def test_cache_hit(self):
         with TemporaryDirectory() as d:
-            cache_path = get_cached_path(TEST_MODEL_HANDLE, cache_dir=d)
-            os.makedirs(cache_path)
+            with mock.patch.dict(os.environ, {CACHE_FOLDER_ENV_VAR_NAME: d}):
+                cache_path = get_cached_path(TEST_MODEL_HANDLE)
+                os.makedirs(cache_path)
 
-            path = load_from_cache(TEST_MODEL_HANDLE, cache_dir=d)
+                path = load_from_cache(TEST_MODEL_HANDLE)
 
-            self.assertEqual(
-                os.path.join(d, MODELS_CACHE_SUBFOLDER, "google", "bert", "tensorFlow2", "answer-equivalence-bem", "2"),
-                path,
-            )
+                self.assertEqual(
+                    os.path.join(
+                        d, MODELS_CACHE_SUBFOLDER, "google", "bert", "tensorFlow2", "answer-equivalence-bem", "2"
+                    ),
+                    path,
+                )
 
     def test_cache_hit_with_path(self):
         with TemporaryDirectory() as d:
-            cache_path = get_cached_path(TEST_MODEL_HANDLE, cache_dir=d)
+            with mock.patch.dict(os.environ, {CACHE_FOLDER_ENV_VAR_NAME: d}):
+                cache_path = get_cached_path(TEST_MODEL_HANDLE)
 
-            os.makedirs(cache_path)
-            Path(os.path.join(cache_path, "foo.txt")).touch()  # Create file
+                os.makedirs(cache_path)
+                Path(os.path.join(cache_path, "foo.txt")).touch()  # Create file
 
-            path = load_from_cache(TEST_MODEL_HANDLE, path="foo.txt", cache_dir=d)
+                path = load_from_cache(TEST_MODEL_HANDLE, path="foo.txt")
 
-            self.assertEqual(
-                os.path.join(
-                    d, MODELS_CACHE_SUBFOLDER, "google", "bert", "tensorFlow2", "answer-equivalence-bem", "2", "foo.txt"
-                ),
-                path,
-            )
+                self.assertEqual(
+                    os.path.join(
+                        d,
+                        MODELS_CACHE_SUBFOLDER,
+                        "google",
+                        "bert",
+                        "tensorFlow2",
+                        "answer-equivalence-bem",
+                        "2",
+                        "foo.txt",
+                    ),
+                    path,
+                )
 
     def test_load_from_cache_invalid_handle(self):
         with self.assertRaises(ValueError):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -46,7 +46,7 @@ class TestCache(unittest.TestCase):
             cache_path = get_cached_path(TEST_MODEL_HANDLE, cache_dir=d)
 
             os.makedirs(cache_path)
-            Path.touch(os.path.join(cache_path, "foo.txt"))  # Create file
+            Path(os.path.join(cache_path, "foo.txt")).touch()  # Create file
 
             path = load_from_cache(TEST_MODEL_HANDLE, path="foo.txt", cache_dir=d)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
+import os
 import unittest
-from test.support.os_helper import EnvironmentVarGuard
+from unittest import mock
 
 from kagglehub.config import CACHE_FOLDER_ENV_VAR_NAME, DEFAULT_CACHE_FOLDER, get_cache_folder
 
@@ -8,8 +9,6 @@ class TestConfig(unittest.TestCase):
     def test_get_cache_folder_default(self):
         self.assertEqual(DEFAULT_CACHE_FOLDER, get_cache_folder())
 
+    @mock.patch.dict(os.environ, {CACHE_FOLDER_ENV_VAR_NAME: "/test_cache"})
     def test_get_cache_folder_environment_var_override(self):
-        env = EnvironmentVarGuard()
-        env.set(CACHE_FOLDER_ENV_VAR_NAME, "/test_cache")
-        with env:
-            self.assertEqual("/test_cache", get_cache_folder())
+        self.assertEqual("/test_cache", get_cache_folder())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,15 @@
+import unittest
+from test.support.os_helper import EnvironmentVarGuard
+
+from kagglehub.config import CACHE_FOLDER_ENV_VAR_NAME, DEFAULT_CACHE_FOLDER, get_cache_folder
+
+
+class TestConfig(unittest.TestCase):
+    def test_get_cache_folder_default(self):
+        self.assertEqual(DEFAULT_CACHE_FOLDER, get_cache_folder())
+
+    def test_get_cache_folder_environment_var_override(self):
+        env = EnvironmentVarGuard()
+        env.set(CACHE_FOLDER_ENV_VAR_NAME, "/test_cache")
+        with env:
+            self.assertEqual("/test_cache", get_cache_folder())

--- a/tests/test_handle.py
+++ b/tests/test_handle.py
@@ -1,0 +1,26 @@
+import unittest
+
+from kagglehub.handle import parse_model_handle
+
+
+class TestHandle(unittest.TestCase):
+    def test_versioned_model_handle(self):
+        h = parse_model_handle("google/bert/tensorFlow2/answer-equivalence-bem/3")
+
+        self.assertEqual("google", h.owner)
+        self.assertEqual("bert", h.model)
+        self.assertEqual("tensorFlow2", h.framework)
+        self.assertEqual("answer-equivalence-bem", h.variation)
+        self.assertEqual(3, h.version)
+
+    def test_unversioned_model_handle(self):
+        with self.assertRaises(NotImplementedError):
+            parse_model_handle("google/bert/tensorFlow2/answer-equivalence-bem")
+
+    def test_invalid_model_handle(self):
+        with self.assertRaises(ValueError):
+            parse_model_handle("invalid")
+
+    def test_invalid_version_model_handle(self):
+        with self.assertRaises(ValueError):
+            parse_model_handle("google/bert/tensorFlow2/answer-equivalence-bem/invalid-version-number")

--- a/tests/test_model_download.py
+++ b/tests/test_model_download.py
@@ -1,11 +1,49 @@
+import os
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import kagglehub
+from kagglehub.cache import MODELS_CACHE_SUBFOLDER, get_cached_path
+from kagglehub.handle import parse_model_handle
 
-MODEL_HANDLE = "metaresearch/llama-2/pyTorch/13b"
+VERSIONED_MODEL_HANDLE = "metaresearch/llama-2/pyTorch/13b/3"
+UNVERSIONED_MODEL_HANDLE = "metaresearch/llama-2/pyTorch/13b"
 
 
 class TestModelDownload(unittest.TestCase):
-    def test_model_download(self):
+    def test_unversioned_model_download(self):
         with self.assertRaises(NotImplementedError):
-            kagglehub.model_download(MODEL_HANDLE)
+            kagglehub.model_download(UNVERSIONED_MODEL_HANDLE)
+
+    def test_versioned_model_download(self):
+        with self.assertRaises(NotImplementedError):
+            kagglehub.model_download(VERSIONED_MODEL_HANDLE)
+
+    def test_versioned_model_download_with_path(self):
+        with self.assertRaises(NotImplementedError):
+            kagglehub.model_download(VERSIONED_MODEL_HANDLE, path="foo.txt")
+
+    def test_versioned_model_download_already_cached(self):
+        with TemporaryDirectory() as d:
+            cache_path = get_cached_path(parse_model_handle(VERSIONED_MODEL_HANDLE), cache_dir=d)
+            os.makedirs(cache_path)
+
+            model_path = kagglehub.model_download(VERSIONED_MODEL_HANDLE, cache_dir=d)
+
+            self.assertEqual(
+                os.path.join(d, MODELS_CACHE_SUBFOLDER, "metaresearch", "llama-2", "pyTorch", "13b", "3"), model_path
+            )
+
+    def test_versioned_model_download_with_path_already_cached(self):
+        with TemporaryDirectory() as d:
+            cache_path = get_cached_path(parse_model_handle(VERSIONED_MODEL_HANDLE), cache_dir=d)
+            os.makedirs(cache_path)
+            Path.touch(os.path.join(cache_path, "foo.txt"))  # Create file
+
+            model_path = kagglehub.model_download(VERSIONED_MODEL_HANDLE, path="foo.txt", cache_dir=d)
+
+            self.assertEqual(
+                os.path.join(d, MODELS_CACHE_SUBFOLDER, "metaresearch", "llama-2", "pyTorch", "13b", "3", "foo.txt"),
+                model_path,
+            )

--- a/tests/test_model_download.py
+++ b/tests/test_model_download.py
@@ -2,9 +2,11 @@ import os
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest import mock
 
 import kagglehub
 from kagglehub.cache import MODELS_CACHE_SUBFOLDER, get_cached_path
+from kagglehub.config import CACHE_FOLDER_ENV_VAR_NAME
 from kagglehub.handle import parse_model_handle
 
 VERSIONED_MODEL_HANDLE = "metaresearch/llama-2/pyTorch/13b/3"
@@ -26,24 +28,29 @@ class TestModelDownload(unittest.TestCase):
 
     def test_versioned_model_download_already_cached(self):
         with TemporaryDirectory() as d:
-            cache_path = get_cached_path(parse_model_handle(VERSIONED_MODEL_HANDLE), cache_dir=d)
-            os.makedirs(cache_path)
+            with mock.patch.dict(os.environ, {CACHE_FOLDER_ENV_VAR_NAME: d}):
+                cache_path = get_cached_path(parse_model_handle(VERSIONED_MODEL_HANDLE))
+                os.makedirs(cache_path)
 
-            model_path = kagglehub.model_download(VERSIONED_MODEL_HANDLE, cache_dir=d)
+                model_path = kagglehub.model_download(VERSIONED_MODEL_HANDLE)
 
-            self.assertEqual(
-                os.path.join(d, MODELS_CACHE_SUBFOLDER, "metaresearch", "llama-2", "pyTorch", "13b", "3"), model_path
-            )
+                self.assertEqual(
+                    os.path.join(d, MODELS_CACHE_SUBFOLDER, "metaresearch", "llama-2", "pyTorch", "13b", "3"),
+                    model_path,
+                )
 
     def test_versioned_model_download_with_path_already_cached(self):
         with TemporaryDirectory() as d:
-            cache_path = get_cached_path(parse_model_handle(VERSIONED_MODEL_HANDLE), cache_dir=d)
-            os.makedirs(cache_path)
-            Path(os.path.join(cache_path, "foo.txt")).touch()  # Create file
+            with mock.patch.dict(os.environ, {CACHE_FOLDER_ENV_VAR_NAME: d}):
+                cache_path = get_cached_path(parse_model_handle(VERSIONED_MODEL_HANDLE))
+                os.makedirs(cache_path)
+                Path(os.path.join(cache_path, "foo.txt")).touch()  # Create file
 
-            model_path = kagglehub.model_download(VERSIONED_MODEL_HANDLE, path="foo.txt", cache_dir=d)
+                model_path = kagglehub.model_download(VERSIONED_MODEL_HANDLE, path="foo.txt")
 
-            self.assertEqual(
-                os.path.join(d, MODELS_CACHE_SUBFOLDER, "metaresearch", "llama-2", "pyTorch", "13b", "3", "foo.txt"),
-                model_path,
-            )
+                self.assertEqual(
+                    os.path.join(
+                        d, MODELS_CACHE_SUBFOLDER, "metaresearch", "llama-2", "pyTorch", "13b", "3", "foo.txt"
+                    ),
+                    model_path,
+                )

--- a/tests/test_model_download.py
+++ b/tests/test_model_download.py
@@ -39,7 +39,7 @@ class TestModelDownload(unittest.TestCase):
         with TemporaryDirectory() as d:
             cache_path = get_cached_path(parse_model_handle(VERSIONED_MODEL_HANDLE), cache_dir=d)
             os.makedirs(cache_path)
-            Path.touch(os.path.join(cache_path, "foo.txt"))  # Create file
+            Path(os.path.join(cache_path, "foo.txt")).touch()  # Create file
 
             model_path = kagglehub.model_download(VERSIONED_MODEL_HANDLE, path="foo.txt", cache_dir=d)
 


### PR DESCRIPTION
Default cache directory is ~/.cache/kagglehub.
Can be overriden globally by KAGGLEHUB_CACHE env variable. Can be overriden for a single call using the `cache_dir` parameter.

Also include logic for parsing the model handle.

Next: Implement downloading file on cache miss.

http://b/305947384