### PR TITLE
Create test utils for setting up a test cache & http server

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,12 +1,11 @@
 import os
 import unittest
 from pathlib import Path
-from tempfile import TemporaryDirectory
-from unittest import mock
 
 from kagglehub.cache import MODELS_CACHE_SUBFOLDER, get_cached_path, load_from_cache, mark_as_complete
-from kagglehub.config import CACHE_FOLDER_ENV_VAR_NAME
 from kagglehub.handle import ModelHandle
+
+from .utils import create_test_cache
 
 TEST_MODEL_HANDLE = ModelHandle(
     owner="google",
@@ -34,86 +33,78 @@ class TestCache(unittest.TestCase):
         self.assertEqual(None, load_from_cache(TEST_MODEL_HANDLE, TEST_FILEPATH))
 
     def test_load_from_cache_not_complete_miss(self):
-        with TemporaryDirectory() as d:
-            with mock.patch.dict(os.environ, {CACHE_FOLDER_ENV_VAR_NAME: d}):
-                cache_path = get_cached_path(TEST_MODEL_HANDLE)
+        with create_test_cache():
+            cache_path = get_cached_path(TEST_MODEL_HANDLE)
 
-                # Should be a cache `miss` if the directory exists but not the marker file.
-                os.makedirs(cache_path)
+            # Should be a cache `miss` if the directory exists but not the marker file.
+            os.makedirs(cache_path)
 
-                self.assertEqual(None, load_from_cache(TEST_MODEL_HANDLE))
+            self.assertEqual(None, load_from_cache(TEST_MODEL_HANDLE))
 
     def test_load_from_cache_with_path_not_complete_miss(self):
-        with TemporaryDirectory() as d:
-            with mock.patch.dict(os.environ, {CACHE_FOLDER_ENV_VAR_NAME: d}):
-                cache_path = get_cached_path(TEST_MODEL_HANDLE)
+        with create_test_cache():
+            cache_path = get_cached_path(TEST_MODEL_HANDLE)
 
-                # Should be a cache `miss` if the directory exists but not the marker file.
-                os.makedirs(cache_path)
-                Path(os.path.join(cache_path, TEST_FILEPATH)).touch()  # Create file
+            # Should be a cache `miss` if the directory exists but not the marker file.
+            os.makedirs(cache_path)
+            Path(os.path.join(cache_path, TEST_FILEPATH)).touch()  # Create file
 
-                self.assertEqual(None, load_from_cache(TEST_MODEL_HANDLE, path=TEST_FILEPATH))
+            self.assertEqual(None, load_from_cache(TEST_MODEL_HANDLE, path=TEST_FILEPATH))
 
     def test_load_from_cache_with_complete_marker_no_files_miss(self):
-        with TemporaryDirectory() as d:
-            with mock.patch.dict(os.environ, {CACHE_FOLDER_ENV_VAR_NAME: d}):
-                get_cached_path(TEST_MODEL_HANDLE)
+        with create_test_cache():
+            get_cached_path(TEST_MODEL_HANDLE)
 
-                # Should be a cache `miss` if completion marker file exists but not the files themselves.
-                mark_as_complete(TEST_MODEL_HANDLE)
+            # Should be a cache `miss` if completion marker file exists but not the files themselves.
+            mark_as_complete(TEST_MODEL_HANDLE)
 
-                self.assertEqual(None, load_from_cache(TEST_MODEL_HANDLE))
+            self.assertEqual(None, load_from_cache(TEST_MODEL_HANDLE))
 
     def test_load_from_cache_with_path_complete_marker_no_files_miss(self):
-        with TemporaryDirectory() as d:
-            with mock.patch.dict(os.environ, {CACHE_FOLDER_ENV_VAR_NAME: d}):
-                get_cached_path(TEST_MODEL_HANDLE)
+        with create_test_cache():
+            get_cached_path(TEST_MODEL_HANDLE)
 
-                # Should be a cache `miss` if completion marker file exists but not the file itself.
-                mark_as_complete(TEST_MODEL_HANDLE, path=TEST_FILEPATH)
+            # Should be a cache `miss` if completion marker file exists but not the file itself.
+            mark_as_complete(TEST_MODEL_HANDLE, path=TEST_FILEPATH)
 
-                self.assertEqual(None, load_from_cache(TEST_MODEL_HANDLE, path=TEST_FILEPATH))
+            self.assertEqual(None, load_from_cache(TEST_MODEL_HANDLE, path=TEST_FILEPATH))
 
     def test_cache_hit(self):
-        with TemporaryDirectory() as d:
-            with mock.patch.dict(os.environ, {CACHE_FOLDER_ENV_VAR_NAME: d}):
-                cache_path = get_cached_path(TEST_MODEL_HANDLE)
-                os.makedirs(cache_path)
-                mark_as_complete(TEST_MODEL_HANDLE)
+        with create_test_cache() as d:
+            cache_path = get_cached_path(TEST_MODEL_HANDLE)
+            os.makedirs(cache_path)
+            mark_as_complete(TEST_MODEL_HANDLE)
 
-                path = load_from_cache(TEST_MODEL_HANDLE)
+            path = load_from_cache(TEST_MODEL_HANDLE)
 
-                self.assertEqual(
-                    os.path.join(
-                        d, MODELS_CACHE_SUBFOLDER, "google", "bert", "tensorFlow2", "answer-equivalence-bem", "2"
-                    ),
-                    path,
-                )
+            self.assertEqual(
+                os.path.join(d, MODELS_CACHE_SUBFOLDER, "google", "bert", "tensorFlow2", "answer-equivalence-bem", "2"),
+                path,
+            )
 
     def test_cache_hit_with_path(self):
-        with TemporaryDirectory() as d:
-            with mock.patch.dict(os.environ, {CACHE_FOLDER_ENV_VAR_NAME: d}):
-                cache_path = get_cached_path(TEST_MODEL_HANDLE)
+        with create_test_cache() as d:
+            cache_path = get_cached_path(TEST_MODEL_HANDLE)
 
-                os.makedirs(cache_path)
-                Path(os.path.join(cache_path, TEST_FILEPATH)).touch()  # Create file
-                mark_as_complete(TEST_MODEL_HANDLE, path=TEST_FILEPATH)
+            os.makedirs(cache_path)
+            Path(os.path.join(cache_path, TEST_FILEPATH)).touch()  # Create file
+            mark_as_complete(TEST_MODEL_HANDLE, path=TEST_FILEPATH)
 
-                path = load_from_cache(TEST_MODEL_HANDLE, path=TEST_FILEPATH)
+            path = load_from_cache(TEST_MODEL_HANDLE, path=TEST_FILEPATH)
 
-                self.assertEqual(
-                    os.path.join(
-                        d,
-                        MODELS_CACHE_SUBFOLDER,
-                        "google",
-                        "bert",
-                        "tensorFlow2",
-                        "answer-equivalence-bem",
-                        "2",
-                        "foo.txt",
-                    ),
-                    path,
-                )
+            self.assertEqual(
+                os.path.join(
+                    d,
+                    MODELS_CACHE_SUBFOLDER,
+                    "google",
+                    "bert",
+                    "tensorFlow2",
+                    "answer-equivalence-bem",
+                    "2",
+                    "foo.txt",
+                ),
+                path,
+            )
 
     def test_load_from_cache_invalid_handle(self):
         with self.assertRaises(ValueError):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,38 @@
 import os
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Type
+from unittest import mock
+from urllib.parse import urlparse
+
+from kagglehub.config import CACHE_FOLDER_ENV_VAR_NAME, KAGGLE_API_ENDPOINT_ENV_VAR_NAME
 
 
 def get_test_file_path(relative_path):
     return os.path.join(Path(__file__).parent, "data", relative_path)
+
+
+@contextmanager
+def create_test_cache():
+    with TemporaryDirectory() as d:
+        with mock.patch.dict(os.environ, {CACHE_FOLDER_ENV_VAR_NAME: d}):
+            yield d
+
+
+@contextmanager
+def create_test_http_server(handler_class: Type[BaseHTTPRequestHandler]):
+    endpoint = os.getenv(KAGGLE_API_ENDPOINT_ENV_VAR_NAME)
+    test_server_address = urlparse(endpoint)
+    if not test_server_address.hostname or not test_server_address.port:
+        msg = f"Invalid test server address: {endpoint}. You must specify a hostname & port"
+        raise ValueError(msg)
+    with HTTPServer((test_server_address.hostname, test_server_address.port), handler_class) as httpd:
+        threading.Thread(target=httpd.serve_forever).start()
+
+        try:
+            yield httpd
+        finally:
+            httpd.shutdown()


### PR DESCRIPTION
The tests are unchanged. Simply using the new contextmanager test utils methods.

http://b/305947384