### PR TITLE
Support unversioned model handles

### DIFF
--- a/src/kagglehub/clients.py
+++ b/src/kagglehub/clients.py
@@ -1,3 +1,4 @@
+import json
 from urllib.parse import urljoin
 
 import requests
@@ -21,6 +22,16 @@ class KaggleApiV1Client:
     def __init__(self):
         self.credentials = get_kaggle_credentials()
         self.endpoint = get_kaggle_api_endpoint()
+
+    def get(self, path: str):
+        url = self._build_url(path)
+        with requests.get(
+            url,
+            auth=self._get_http_basic_auth(),
+            timeout=(DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT),
+        ) as response:
+            response.raise_for_status()
+            return json.loads(response.content)
 
     def download_file(self, path: str, out_file: str):
         url = self._build_url(path)

--- a/src/kagglehub/handle.py
+++ b/src/kagglehub/handle.py
@@ -1,5 +1,6 @@
 """Functions to parse resource handles."""
 from dataclasses import dataclass
+from typing import Optional
 
 NUM_VERSIONED_MODEL_PARTS = 5  # e.g.: <owner>/<model>/<framework>/<variation>/<version>
 NUM_UNVERSIONED_MODEL_PARTS = 4  # e.g.: <owner>/<model>/<framework>/<variation>
@@ -11,7 +12,10 @@ class ModelHandle:
     model: str
     framework: str
     variation: str
-    version: int
+    version: Optional[int]
+
+    def is_versioned(self):
+        return self.version and self.version > 0
 
 
 def parse_model_handle(handle: str) -> ModelHandle:
@@ -36,8 +40,13 @@ def parse_model_handle(handle: str) -> ModelHandle:
     elif len(parts) == NUM_UNVERSIONED_MODEL_PARTS:
         # Unversioned handle
         # e.g.: <owner>/<model>/<framework>/<variation>
-        msg = "Unversioned model handle is not yet supported"
-        raise NotImplementedError(msg)
+        return ModelHandle(
+            owner=parts[0],
+            model=parts[1],
+            framework=parts[2],
+            variation=parts[3],
+            version=None,
+        )
 
     msg = f"Invalid model handle: {handle}"
     raise ValueError(msg)

--- a/tests/test_handle.py
+++ b/tests/test_handle.py
@@ -12,10 +12,16 @@ class TestHandle(unittest.TestCase):
         self.assertEqual("tensorFlow2", h.framework)
         self.assertEqual("answer-equivalence-bem", h.variation)
         self.assertEqual(3, h.version)
+        self.assertTrue(h.is_versioned())
 
     def test_unversioned_model_handle(self):
-        with self.assertRaises(NotImplementedError):
-            parse_model_handle("google/bert/tensorFlow2/answer-equivalence-bem")
+        h = parse_model_handle("google/bert/tensorFlow2/answer-equivalence-bem")
+        self.assertEqual("google", h.owner)
+        self.assertEqual("bert", h.model)
+        self.assertEqual("tensorFlow2", h.framework)
+        self.assertEqual("answer-equivalence-bem", h.variation)
+        self.assertEqual(None, h.version)
+        self.assertFalse(h.is_versioned())
 
     def test_invalid_model_handle(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
The following now works:

```
kagglehub.model_download('keras-nlp/albert/keras/albert_base_en_uncased')
```

http://b/306408547