### PR TITLE
Support resumable download

### DIFF
--- a/src/kagglehub/__init__.py
+++ b/src/kagglehub/__init__.py
@@ -1,5 +1,6 @@
 __version__ = "0.0.1a1"
 
+import kagglehub.logging
 from kagglehub import http_resolver, registry
 from kagglehub.auth import login
 from kagglehub.models import model_download, model_upload

--- a/src/kagglehub/cache.py
+++ b/src/kagglehub/cache.py
@@ -33,6 +33,14 @@ def get_cached_path(handle: Union[ModelHandle], path: Optional[str] = None) -> s
         raise ValueError(msg)
 
 
+def get_cached_archive_path(handle: Union[ModelHandle]) -> str:
+    if isinstance(handle, ModelHandle):
+        return _get_model_archive_path(handle)
+    else:
+        msg = "Invalid handle"
+        raise ValueError(msg)
+
+
 def mark_as_complete(handle: Union[ModelHandle], path: Optional[str] = None):
     marker_path = _get_completion_marker_filepath(handle, path)
     os.makedirs(os.path.dirname(marker_path), exist_ok=True)
@@ -60,6 +68,18 @@ def _get_model_path(handle: ModelHandle, path: Optional[str] = None):
     )
 
     return os.path.join(base_path, path) if path else base_path
+
+
+def _get_model_archive_path(handle: ModelHandle):
+    return os.path.join(
+        get_cache_folder(),
+        MODELS_CACHE_SUBFOLDER,
+        handle.owner,
+        handle.model,
+        handle.framework,
+        handle.variation,
+        f"{handle.version!s}.archive",
+    )
 
 
 def _get_models_completion_marker_filepath(handle: ModelHandle, path: Optional[str] = None):

--- a/src/kagglehub/clients.py
+++ b/src/kagglehub/clients.py
@@ -1,4 +1,6 @@
 import json
+import logging
+import os
 from urllib.parse import urljoin
 
 import requests
@@ -13,6 +15,9 @@ CHUNK_SIZE = 1048576
 # See: https://requests.readthedocs.io/en/stable/user/advanced/#timeouts
 DEFAULT_CONNECT_TIMEOUT = 5  # seconds
 DEFAULT_READ_TIMEOUT = 15  # seconds
+ACCEPT_RANGE_HTTP_HEADER = "Accept-Ranges"
+
+logger = logging.getLogger(__name__)
 
 
 # TODO(b/307576378): When ready, use `kagglesdk` to issue requests.
@@ -35,7 +40,6 @@ class KaggleApiV1Client:
 
     def download_file(self, path: str, out_file: str):
         url = self._build_url(path)
-        # TODO(b/307572374) Support resumable downloads.
         with requests.get(
             url,
             stream=True,
@@ -43,19 +47,44 @@ class KaggleApiV1Client:
             timeout=(DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT),
         ) as response:
             response.raise_for_status()
-            size = int(response.headers["Content-Length"])
+            total_size = int(response.headers["Content-Length"])
             size_read = 0
-            with tqdm(total=size, initial=size_read, unit="B", unit_scale=True, unit_divisor=1024) as progress_bar:
-                with open(out_file, "wb") as f:
-                    for chunk in response.iter_content(CHUNK_SIZE):
-                        f.write(chunk)
-                        size_read = min(size, size_read + CHUNK_SIZE)
-                        progress_bar.update(len(chunk))
+
+            if _is_resumable(response) and os.path.isfile(out_file):
+                size_read = os.path.getsize(out_file)
+
+                logger.info(f"Resuming download from {size_read} bytes ({total_size - size_read} bytes left)...")
+
+                # Send the request again with the 'Range' header.
+                with requests.get(
+                    response.url,  # URL after redirection
+                    stream=True,
+                    auth=self._get_http_basic_auth(),
+                    timeout=(DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT),
+                    headers={"Range": f"bytes={size_read}-"},
+                ) as resumed_response:
+                    _download_file(resumed_response, out_file, size_read, total_size)
+            else:
+                _download_file(response, out_file, size_read, total_size)
 
     def _get_http_basic_auth(self):
         if self.credentials:
             return HTTPBasicAuth(self.credentials.username, self.credentials.key)
         return None
 
-    def _build_url(self, path):
+    def _build_url(self, path: str):
         return urljoin(self.endpoint, f"{KaggleApiV1Client.BASE_PATH}/{path}")
+
+
+def _is_resumable(response: requests.Response):
+    return ACCEPT_RANGE_HTTP_HEADER in response.headers and response.headers[ACCEPT_RANGE_HTTP_HEADER] == "bytes"
+
+
+def _download_file(response: requests.Response, out_file: str, size_read: int, total_size: int):
+    open_mode = "ab" if size_read > 0 else "wb"
+    with tqdm(total=total_size, initial=size_read, unit="B", unit_scale=True, unit_divisor=1024) as progress_bar:
+        with open(out_file, open_mode) as f:
+            for chunk in response.iter_content(CHUNK_SIZE):
+                f.write(chunk)
+                size_read = min(total_size, size_read + CHUNK_SIZE)
+                progress_bar.update(len(chunk))

--- a/src/kagglehub/config.py
+++ b/src/kagglehub/config.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -6,6 +7,7 @@ from pathlib import Path
 DEFAULT_CACHE_FOLDER = os.path.join(Path.home(), ".cache", "kagglehub")
 DEFAULT_KAGGLE_API_ENDPOINT = "https://www.kaggle.com"
 DEFAULT_KAGGLE_CREDENTIALS_FOLDER = os.path.join(Path.home(), ".kaggle")
+DEFAULT_LOG_LEVEL = logging.INFO
 CREDENTIALS_FILENAME = "kaggle.json"
 
 CACHE_FOLDER_ENV_VAR_NAME = "KAGGLEHUB_CACHE"
@@ -13,9 +15,20 @@ KAGGLE_API_ENDPOINT_ENV_VAR_NAME = "KAGGLE_API_ENDPOINT"
 USERNAME_ENV_VAR_NAME = "KAGGLE_USERNAME"
 KEY_ENV_VAR_NAME = "KAGGLE_KEY"
 CREDENTIALS_FOLDER_ENV_VAR_NAME = "KAGGLE_CONFIG_DIR"
+LOG_VERBOSITY_ENV_VAR_NAME = "KAGGLEHUB_VERBOSITY"
 
 CREDENTIALS_JSON_USERNAME = "username"
 CREDENTIALS_JSON_KEY = "key"
+
+LOG_LEVELS_MAP = {
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+    "critical": logging.CRITICAL,
+}
+
+logger = logging.getLogger(__name__)
 
 
 def get_cache_folder():
@@ -56,6 +69,19 @@ def get_kaggle_credentials():
             )
 
     return None
+
+
+def get_log_verbosity():
+    if LOG_VERBOSITY_ENV_VAR_NAME in os.environ:
+        log_level_str = os.environ[LOG_VERBOSITY_ENV_VAR_NAME]
+        if log_level_str in LOG_LEVELS_MAP:
+            return LOG_LEVELS_MAP[log_level_str]
+        else:
+            logger.warning(
+                f"Unknown verbosity level set with {LOG_VERBOSITY_ENV_VAR_NAME}={log_level_str}, "
+                f"Accepted values are: {', '.join(LOG_LEVELS_MAP.keys())}"
+            )
+    return DEFAULT_LOG_LEVEL
 
 
 def _get_kaggle_credentials_file():

--- a/src/kagglehub/logging.py
+++ b/src/kagglehub/logging.py
@@ -1,0 +1,13 @@
+import logging
+
+from kagglehub.config import get_log_verbosity
+
+
+def _configure_logger():
+    library_name = __name__.split(".")[0]  # i.e. "kagglehub"
+    library_logger = logging.getLogger(library_name)
+    library_logger.addHandler(logging.StreamHandler())
+    library_logger.setLevel(get_log_verbosity())
+
+
+_configure_logger()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -2,7 +2,13 @@ import os
 import unittest
 from pathlib import Path
 
-from kagglehub.cache import MODELS_CACHE_SUBFOLDER, get_cached_path, load_from_cache, mark_as_complete
+from kagglehub.cache import (
+    MODELS_CACHE_SUBFOLDER,
+    get_cached_archive_path,
+    get_cached_path,
+    load_from_cache,
+    mark_as_complete,
+)
 from kagglehub.handle import ModelHandle
 
 from .utils import create_test_cache
@@ -109,3 +115,20 @@ class TestCache(unittest.TestCase):
     def test_load_from_cache_invalid_handle(self):
         with self.assertRaises(ValueError):
             load_from_cache("invalid_handle")
+
+    def test_model_archive_path(self):
+        with create_test_cache() as d:
+            archive_path = get_cached_archive_path(TEST_MODEL_HANDLE)
+
+            self.assertEqual(
+                os.path.join(
+                    d,
+                    MODELS_CACHE_SUBFOLDER,
+                    "google",
+                    "bert",
+                    "tensorFlow2",
+                    "answer-equivalence-bem",
+                    "2.archive",
+                ),
+                archive_path,
+            )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import unittest
 from tempfile import TemporaryDirectory
@@ -11,10 +12,12 @@ from kagglehub.config import (
     DEFAULT_CACHE_FOLDER,
     KAGGLE_API_ENDPOINT_ENV_VAR_NAME,
     KEY_ENV_VAR_NAME,
+    LOG_VERBOSITY_ENV_VAR_NAME,
     USERNAME_ENV_VAR_NAME,
     get_cache_folder,
     get_kaggle_api_endpoint,
     get_kaggle_credentials,
+    get_log_verbosity,
 )
 
 
@@ -97,3 +100,14 @@ class TestConfig(unittest.TestCase):
                     )
 
                 self.assertRaises(ValueError, get_kaggle_credentials)
+
+    def test_get_log_verbosity_default(self):
+        self.assertEqual(logging.INFO, get_log_verbosity())
+
+    @mock.patch.dict(os.environ, {LOG_VERBOSITY_ENV_VAR_NAME: "error"})
+    def test_get_log_verbosity_environment_var_override(self):
+        self.assertEqual(logging.ERROR, get_log_verbosity())
+
+    @mock.patch.dict(os.environ, {LOG_VERBOSITY_ENV_VAR_NAME: "invalid"})
+    def test_get_log_verbosity_environment_var_override_invalid_value_use_default(self):
+        self.assertEqual(logging.INFO, get_log_verbosity())

--- a/tests/test_model_download.py
+++ b/tests/test_model_download.py
@@ -4,7 +4,8 @@ import unittest
 from http.server import BaseHTTPRequestHandler
 
 import kagglehub
-from kagglehub.cache import MODELS_CACHE_SUBFOLDER
+from kagglehub.cache import MODELS_CACHE_SUBFOLDER, get_cached_archive_path
+from kagglehub.handle import parse_model_handle
 from kagglehub.http_resolver import MODEL_INSTANCE_VERSION_FIELD
 
 from .utils import create_test_cache, create_test_http_server, get_test_file_path
@@ -76,6 +77,10 @@ class TestModelDownload(unittest.TestCase):
                     model_path,
                 )
                 self.assertEqual(["config.json", "model.keras"], sorted(os.listdir(model_path)))
+
+                # Assert that the archive file has been deleted.
+                archive_path = get_cached_archive_path(parse_model_handle(VERSIONED_MODEL_HANDLE))
+                self.assertFalse(os.path.exists(archive_path))
 
     def test_versioned_model_full_download_with_file_already_cached(self):
         with create_test_cache() as d:


### PR DESCRIPTION
- Supports full model & single file downloads
- Updated client to send HTTP "Range" header on resume.
- Use a fixed path for the archive to allow resuming.
- Setup logging infra (and use it to print the resuming state).
Example:

```
$ kagglehub.model_download('keras-nlp/albert/keras/albert_extra_extra_large_en_uncased/1')
3%|███                | 25.0M/789M [00:00<00:13, [00:00<00:13, 59.6MB/s]

# CTRL+D to kill the process

$ kagglehub.model_download('keras-nlp/albert/keras/albert_extra_extra_large_en_uncased/1')
Resuming download from 29360128 bytes (798274426 bytes left)...
100%|█████████████████| 789M/789M [00:09<00:00, 84.7MB/s]
```

http://b/307572374