### PR TITLE
Parse handler earlier & cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ You have 3 different options to authenticate
 
 #### Option 1: Calling kagglehub.login()
 
-```
+```python
+import kagglehub
+
 # TODO(b/305808471): Not yet implemented.
 kagglehub.login()
 ```
@@ -31,7 +33,7 @@ kagglehub.login()
 
 You can also choose to export your Kaggle username and token to the environment:
 
-```
+```sh
 export KAGGLE_USERNAME=datadinosaur
 export KAGGLE_KEY=xxxxxxxxxxxxxx
 ```
@@ -46,9 +48,17 @@ Note for Windows users: The default directory is `%HOMEPATH%/kaggle.json`.
 
 ### Download Model
 
-```
-# TODO(b/305947384) Not yet implemented
-kagglehub.model_download(...)
+The following examples download the `answer-equivalence-bem` variation under for this Kaggle model: https://www.kaggle.com/models/google/bert
+
+
+```python
+import kagglehub
+
+# Download the latest version.
+kagglehub.model_download('google/bert/tensorFlow2/answer-equivalence-bem')
+
+# Download a specific version.
+kagglehub.model_download('google/bert/tensorFlow2/answer-equivalence-bem/1')
 ```
 
 ## Development
@@ -61,7 +71,7 @@ Follow these [instructions](https://hatch.pypa.io/latest/install/) to install it
 
 ### Tests
 
-```
+```sh
 # Run all tests
 hatch run test
 
@@ -71,7 +81,7 @@ hatch run test tests/test_<SOME_FILE>.py
 
 ### Lint / Format
 
-```
+```sh
 # Lint check
 hatch run lint:style
 hatch run lint:typing
@@ -83,12 +93,12 @@ hatch run lint:fmt
 
 ### Coverage report
 
-```
+```sh
 hatch cov
 ```
 
 ### Build
 
-```
+```sh
 hatch build
 ```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Note for Windows users: The default directory is `%HOMEPATH%/kaggle.json`.
 
 ### Download Model
 
-The following examples download the `answer-equivalence-bem` variation under for this Kaggle model: https://www.kaggle.com/models/google/bert
+The following examples download the `answer-equivalence-bem` variation of this Kaggle model: https://www.kaggle.com/models/google/bert
 
 
 ```python

--- a/src/kagglehub/cache.py
+++ b/src/kagglehub/cache.py
@@ -47,7 +47,7 @@ def mark_as_complete(handle: Union[ModelHandle], path: Optional[str] = None):
     Path(marker_path).touch()
 
 
-def _get_completion_marker_filepath(handle: Union[ModelHandle], path: Optional[str] = None):
+def _get_completion_marker_filepath(handle: Union[ModelHandle], path: Optional[str] = None) -> str:
     # Can extend to add support for other resources like DatasetHandle.
     if isinstance(handle, ModelHandle):
         return _get_models_completion_marker_filepath(handle, path)
@@ -56,7 +56,7 @@ def _get_completion_marker_filepath(handle: Union[ModelHandle], path: Optional[s
         raise ValueError(msg)
 
 
-def _get_model_path(handle: ModelHandle, path: Optional[str] = None):
+def _get_model_path(handle: ModelHandle, path: Optional[str] = None) -> str:
     base_path = os.path.join(
         get_cache_folder(),
         MODELS_CACHE_SUBFOLDER,
@@ -70,7 +70,7 @@ def _get_model_path(handle: ModelHandle, path: Optional[str] = None):
     return os.path.join(base_path, path) if path else base_path
 
 
-def _get_model_archive_path(handle: ModelHandle):
+def _get_model_archive_path(handle: ModelHandle) -> str:
     return os.path.join(
         get_cache_folder(),
         MODELS_CACHE_SUBFOLDER,
@@ -82,7 +82,7 @@ def _get_model_archive_path(handle: ModelHandle):
     )
 
 
-def _get_models_completion_marker_filepath(handle: ModelHandle, path: Optional[str] = None):
+def _get_models_completion_marker_filepath(handle: ModelHandle, path: Optional[str] = None) -> str:
     if path:
         return os.path.join(
             get_cache_folder(),

--- a/src/kagglehub/clients.py
+++ b/src/kagglehub/clients.py
@@ -28,7 +28,7 @@ class KaggleApiV1Client:
         self.credentials = get_kaggle_credentials()
         self.endpoint = get_kaggle_api_endpoint()
 
-    def get(self, path: str) -> dict[str, str]:
+    def get(self, path: str) -> dict:
         url = self._build_url(path)
         with requests.get(
             url,

--- a/src/kagglehub/clients.py
+++ b/src/kagglehub/clients.py
@@ -28,7 +28,7 @@ class KaggleApiV1Client:
         self.credentials = get_kaggle_credentials()
         self.endpoint = get_kaggle_api_endpoint()
 
-    def get(self, path: str):
+    def get(self, path: str) -> dict[str, str]:
         url = self._build_url(path)
         with requests.get(
             url,

--- a/src/kagglehub/config.py
+++ b/src/kagglehub/config.py
@@ -3,6 +3,7 @@ import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 DEFAULT_CACHE_FOLDER = os.path.join(Path.home(), ".cache", "kagglehub")
 DEFAULT_KAGGLE_API_ENDPOINT = "https://www.kaggle.com"
@@ -31,19 +32,25 @@ LOG_LEVELS_MAP = {
 logger = logging.getLogger(__name__)
 
 
-def get_cache_folder():
+@dataclass
+class KaggleApiCredentials:
+    username: str
+    key: str
+
+
+def get_cache_folder() -> str:
     if CACHE_FOLDER_ENV_VAR_NAME in os.environ:
         return os.environ[CACHE_FOLDER_ENV_VAR_NAME]
     return DEFAULT_CACHE_FOLDER
 
 
-def get_kaggle_api_endpoint():
+def get_kaggle_api_endpoint() -> str:
     if KAGGLE_API_ENDPOINT_ENV_VAR_NAME in os.environ:
         return os.environ[KAGGLE_API_ENDPOINT_ENV_VAR_NAME]
     return DEFAULT_KAGGLE_API_ENDPOINT
 
 
-def get_kaggle_credentials():
+def get_kaggle_credentials() -> Optional[KaggleApiCredentials]:
     creds_filepath = _get_kaggle_credentials_file()
 
     if USERNAME_ENV_VAR_NAME in os.environ and KEY_ENV_VAR_NAME in os.environ:
@@ -71,7 +78,7 @@ def get_kaggle_credentials():
     return None
 
 
-def get_log_verbosity():
+def get_log_verbosity() -> int:
     if LOG_VERBOSITY_ENV_VAR_NAME in os.environ:
         log_level_str = os.environ[LOG_VERBOSITY_ENV_VAR_NAME]
         if log_level_str in LOG_LEVELS_MAP:
@@ -84,17 +91,11 @@ def get_log_verbosity():
     return DEFAULT_LOG_LEVEL
 
 
-def _get_kaggle_credentials_file():
+def _get_kaggle_credentials_file() -> str:
     return os.path.join(_get_kaggle_credentials_folder(), CREDENTIALS_FILENAME)
 
 
-def _get_kaggle_credentials_folder():
+def _get_kaggle_credentials_folder() -> str:
     if CREDENTIALS_FOLDER_ENV_VAR_NAME in os.environ:
         return os.environ[CREDENTIALS_FOLDER_ENV_VAR_NAME]
     return DEFAULT_KAGGLE_CREDENTIALS_FOLDER
-
-
-@dataclass
-class KaggleApiCredentials:
-    username: str
-    key: str

--- a/src/kagglehub/handle.py
+++ b/src/kagglehub/handle.py
@@ -14,8 +14,8 @@ class ModelHandle:
     variation: str
     version: Optional[int]
 
-    def is_versioned(self):
-        return self.version and self.version > 0
+    def is_versioned(self) -> bool:
+        return self.version is not None and self.version > 0
 
 
 def parse_model_handle(handle: str) -> ModelHandle:

--- a/src/kagglehub/http_resolver.py
+++ b/src/kagglehub/http_resolver.py
@@ -4,19 +4,18 @@ from typing import Optional
 
 from kagglehub.cache import get_cached_archive_path, get_cached_path, load_from_cache, mark_as_complete
 from kagglehub.clients import KaggleApiV1Client
-from kagglehub.handle import ModelHandle, parse_model_handle
+from kagglehub.handle import ModelHandle
 from kagglehub.resolver import Resolver
 
 MODEL_INSTANCE_VERSION_FIELD = "versionNumber"
 
 
 class HttpResolver(Resolver):
-    def is_supported(self, *_):
+    def is_supported(self, *_) -> bool:
         # Downloading files over HTTP is supported in all environments for all handles / path.
         return True
 
-    def __call__(self, handle: str, path: Optional[str] = None):
-        h = parse_model_handle(handle)
+    def __call__(self, h: ModelHandle, path: Optional[str] = None) -> str:
         api_client = KaggleApiV1Client()
 
         if not h.is_versioned():
@@ -70,9 +69,9 @@ def _get_current_version(api_client: KaggleApiV1Client, h: ModelHandle):
     return json_response[MODEL_INSTANCE_VERSION_FIELD]
 
 
-def _build_get_instance_url_path(h: ModelHandle):
+def _build_get_instance_url_path(h: ModelHandle) -> str:
     return f"models/{h.owner}/{h.model}/{h.framework}/{h.variation}/get"
 
 
-def _build_download_url_path(h: ModelHandle):
+def _build_download_url_path(h: ModelHandle) -> str:
     return f"models/{h.owner}/{h.model}/{h.framework}/{h.variation}/{h.version}/download"

--- a/src/kagglehub/models.py
+++ b/src/kagglehub/models.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from kagglehub import registry
+from kagglehub.handle import parse_model_handle
 
 
 def model_download(handle: str, path: Optional[str] = None):
@@ -13,7 +14,8 @@ def model_download(handle: str, path: Optional[str] = None):
     Returns:
         A string representing the path to the requested model files.
     """
-    return registry.resolver(handle, path)
+    h = parse_model_handle(handle)
+    return registry.resolver(h, path)
 
 
 def model_upload():

--- a/src/kagglehub/resolver.py
+++ b/src/kagglehub/resolver.py
@@ -1,6 +1,8 @@
 import abc
 from typing import Optional
 
+from kagglehub.handle import ModelHandle
+
 
 class Resolver:
     """Resolver base class: all resolvers inherit from this class."""
@@ -8,7 +10,7 @@ class Resolver:
     __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
-    def __call__(self, handle: str, path: Optional[str] = None) -> str:
+    def __call__(self, handle: ModelHandle, path: Optional[str] = None) -> str:
         """Resolves a handle into a path with the requested model files.
 
         Args:

--- a/src/kagglehub/resolver.py
+++ b/src/kagglehub/resolver.py
@@ -24,6 +24,6 @@ class Resolver:
         pass
 
     @abc.abstractmethod
-    def is_supported(self, handle: str, path: Optional[str] = None):
+    def is_supported(self, handle: ModelHandle, path: Optional[str] = None):
         """Returns whether the current environment supports this handle/path."""
         pass


### PR DESCRIPTION
- Parse handler in model_download instead of the resolver (will avoid having to do this for each resolver).
- Added missing method return type hints.
- Added documentation to README.md