### PR TITLE
Implement Kaggle Cache Resolver

### DIFF
--- a/src/kagglehub/__init__.py
+++ b/src/kagglehub/__init__.py
@@ -1,9 +1,9 @@
 __version__ = "0.0.1a1"
 
 import kagglehub.logging
-from kagglehub import http_resolver, registry
+from kagglehub import http_resolver, kaggle_cache_resolver, registry
 from kagglehub.auth import login
 from kagglehub.models import model_download, model_upload
 
 registry.resolver.add_implementation(http_resolver.HttpResolver())
-# TODO(b/305947763): Implement Kaggle Cache resolver.
+registry.resolver.add_implementation(kaggle_cache_resolver.KaggleCacheResolver())

--- a/src/kagglehub/clients.py
+++ b/src/kagglehub/clients.py
@@ -8,6 +8,7 @@ from requests.auth import HTTPBasicAuth
 from tqdm import tqdm
 
 from kagglehub.config import get_kaggle_api_endpoint, get_kaggle_credentials
+from kagglehub.exceptions import BackendError, CredentialError, KaggleEnvironmentError
 
 CHUNK_SIZE = 1048576
 # The `connect` timeout is the number of seconds `requests` will wait for your client to establish a connection.
@@ -36,7 +37,7 @@ class KaggleApiV1Client:
             timeout=(DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT),
         ) as response:
             response.raise_for_status()
-            return json.loads(response.content)
+            return response.json()
 
     def download_file(self, path: str, out_file: str):
         url = self._build_url(path)
@@ -88,3 +89,51 @@ def _download_file(response: requests.Response, out_file: str, size_read: int, t
                 f.write(chunk)
                 size_read = min(total_size, size_read + CHUNK_SIZE)
                 progress_bar.update(len(chunk))
+
+
+# These environment variables are set by the Kaggle notebook environment.
+KAGGLE_URL_BASE_ENV_VAR_NAME = "KAGGLE_URL_BASE"
+KAGGLE_JWT_TOKEN_ENV_VAR_NAME = "KAGGLE_USER_SECRETS_TOKEN"
+KAGGLE_IAP_TOKEN_ENV_VAR_NAME = "KAGGLE_IAP_TOKEN"
+
+
+class KaggleJwtClient:
+    BASE_PATH = "/requests/"
+
+    def __init__(self):
+        self.endpoint = os.getenv(KAGGLE_URL_BASE_ENV_VAR_NAME)
+        if self.endpoint is None:
+            msg = f"The {KAGGLE_URL_BASE_ENV_VAR_NAME} should be set."
+            raise KaggleEnvironmentError(msg)
+        jwt_token = os.getenv(KAGGLE_JWT_TOKEN_ENV_VAR_NAME)
+        if jwt_token is None:
+            msg = (
+                "A JWT Token is required to call Kaggle, "
+                f"but none found in environment variable {KAGGLE_JWT_TOKEN_ENV_VAR_NAME}"
+            )
+            raise CredentialError(msg)
+        self.headers = {"Content-type": "application/json", "X-Kaggle-Authorization": f"Bearer {jwt_token}"}
+        iap_token = os.getenv(KAGGLE_IAP_TOKEN_ENV_VAR_NAME)
+        if iap_token:
+            self.headers["Authorization"] = f"Bearer {iap_token}"
+
+    def post(self, request_name: str, data: dict) -> dict:
+        url = f"{self.endpoint}{KaggleJwtClient.BASE_PATH}{request_name}"
+        with requests.post(
+            url,
+            headers=self.headers,
+            data=bytes(json.dumps(data), "utf-8"),
+            timeout=(DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT),
+        ) as response:
+            response.raise_for_status()
+            json_response = response.json()
+            if "wasSuccessful" not in json_response:
+                msg = "'wasSuccessful' field missing from response"
+                raise BackendError(msg)
+            if not json_response["wasSuccessful"]:
+                msg = f"POST failed with: {response.text!s}"
+                raise BackendError(msg)
+            if "result" not in json_response:
+                msg = "'result' field missing from response"
+                raise BackendError(msg)
+            return json_response["result"]

--- a/src/kagglehub/config.py
+++ b/src/kagglehub/config.py
@@ -1,3 +1,8 @@
+"""Retrieve config values that a user may set/override.
+
+For config values specific to a resolver's environment (a user is not expected to override),
+add it to the resolver's module.
+"""
 import json
 import logging
 import os
@@ -17,6 +22,7 @@ USERNAME_ENV_VAR_NAME = "KAGGLE_USERNAME"
 KEY_ENV_VAR_NAME = "KAGGLE_KEY"
 CREDENTIALS_FOLDER_ENV_VAR_NAME = "KAGGLE_CONFIG_DIR"
 LOG_VERBOSITY_ENV_VAR_NAME = "KAGGLEHUB_VERBOSITY"
+DISABLE_KAGGLE_CACHE_ENV_VAR_NAME = "DISABLE_KAGGLE_CACHE"
 
 CREDENTIALS_JSON_USERNAME = "username"
 CREDENTIALS_JSON_KEY = "key"
@@ -28,6 +34,7 @@ LOG_LEVELS_MAP = {
     "error": logging.ERROR,
     "critical": logging.CRITICAL,
 }
+TRUTHY_VALUES = ["true", "1", "t"]
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +98,10 @@ def get_log_verbosity() -> int:
     return DEFAULT_LOG_LEVEL
 
 
+def is_kaggle_cache_disabled() -> bool:
+    return _is_env_var_truthy(DISABLE_KAGGLE_CACHE_ENV_VAR_NAME)
+
+
 def _get_kaggle_credentials_file() -> str:
     return os.path.join(_get_kaggle_credentials_folder(), CREDENTIALS_FILENAME)
 
@@ -99,3 +110,7 @@ def _get_kaggle_credentials_folder() -> str:
     if CREDENTIALS_FOLDER_ENV_VAR_NAME in os.environ:
         return os.environ[CREDENTIALS_FOLDER_ENV_VAR_NAME]
     return DEFAULT_KAGGLE_CREDENTIALS_FOLDER
+
+
+def _is_env_var_truthy(env_var_name: str) -> bool:
+    return env_var_name in os.environ and os.environ[env_var_name].lower() in TRUTHY_VALUES

--- a/src/kagglehub/exceptions.py
+++ b/src/kagglehub/exceptions.py
@@ -1,0 +1,10 @@
+class CredentialError(Exception):
+    pass
+
+
+class KaggleEnvironmentError(Exception):
+    pass
+
+
+class BackendError(Exception):
+    pass

--- a/src/kagglehub/handle.py
+++ b/src/kagglehub/handle.py
@@ -17,7 +17,7 @@ class ModelHandle:
     def is_versioned(self) -> bool:
         return self.version is not None and self.version > 0
 
-    def __str__(self):
+    def __str__(self) -> str:
         handle_str = f"{self.owner}/{self.model}/{self.framework}/{self.variation}"
         if self.is_versioned():
             return f"{handle_str}/{self.version}"

--- a/src/kagglehub/handle.py
+++ b/src/kagglehub/handle.py
@@ -17,6 +17,12 @@ class ModelHandle:
     def is_versioned(self) -> bool:
         return self.version is not None and self.version > 0
 
+    def __str__(self):
+        handle_str = f"{self.owner}/{self.model}/{self.framework}/{self.variation}"
+        if self.is_versioned():
+            return f"{handle_str}/{self.version}"
+        return handle_str
+
 
 def parse_model_handle(handle: str) -> ModelHandle:
     parts = handle.split("/")

--- a/src/kagglehub/kaggle_cache_resolver.py
+++ b/src/kagglehub/kaggle_cache_resolver.py
@@ -1,0 +1,79 @@
+import logging
+import os
+import time
+from typing import Optional
+
+from kagglehub.clients import KAGGLE_URL_BASE_ENV_VAR_NAME, KaggleJwtClient
+from kagglehub.config import is_kaggle_cache_disabled
+from kagglehub.exceptions import BackendError
+from kagglehub.handle import ModelHandle
+from kagglehub.resolver import Resolver
+
+KAGGLE_NOTEBOOK_ENV_VAR_NAME = "KAGGLE_KERNEL_RUN_TYPE"
+KAGGLE_CACHE_MOUNT_FOLDER_ENV_VAR_NAME = "KAGGLE_CACHE_MOUNT_FOLDER"
+ATTACH_DATASOURCE_REQUEST_NAME = "AttachDatasourceUsingJwtRequest"
+
+DEFAULT_KAGGLE_CACHE_MOUNT_FOLDER = "/kaggle/input/"
+
+
+logger = logging.getLogger(__name__)
+
+
+class KaggleCacheResolver(Resolver):
+    def is_supported(self, *_) -> bool:
+        if is_kaggle_cache_disabled():
+            return False
+
+        if KAGGLE_NOTEBOOK_ENV_VAR_NAME in os.environ:
+            # Inside a Kaggle notebook.
+            if KAGGLE_URL_BASE_ENV_VAR_NAME not in os.environ:
+                # Missing endpoint for the Jwt client.
+                logger.warning(
+                    f"Can't use the Kaggle Cache. The '{KAGGLE_URL_BASE_ENV_VAR_NAME}' environment variable is not set."
+                )
+                return False
+            return True
+
+        return False
+
+    def __call__(self, h: ModelHandle, path: Optional[str] = None) -> str:
+        logger.info(f"Attaching model '{h}' to your Kaggle notebook...")
+        client = KaggleJwtClient()
+        model_ref = {
+            "OwnerSlug": h.owner,
+            "ModelSlug": h.model,
+            "Framework": h.framework,
+            "InstanceSlug": h.variation,
+        }
+        if h.is_versioned():
+            model_ref["VersionNumber"] = str(h.version)
+
+        result = client.post(
+            ATTACH_DATASOURCE_REQUEST_NAME,
+            {
+                "modelRef": model_ref,
+            },
+        )
+        if "mountSlug" not in result:
+            msg = "'result.mountSlug' field missing from response"
+            raise BackendError(msg)
+
+        base_mount_path = os.getenv(KAGGLE_CACHE_MOUNT_FOLDER_ENV_VAR_NAME, DEFAULT_KAGGLE_CACHE_MOUNT_FOLDER)
+        cached_path = f"{base_mount_path}/{result['mountSlug']}"
+
+        logger.info(f"Mounting files to {cached_path}...")
+        while not os.path.exists(cached_path):
+            time.sleep(5)
+
+        logger.info(f"Model '{h}' is attached.")
+
+        if path:
+            cached_filepath = f"{cached_path}/{path}"
+            if not os.path.exists(cached_filepath):
+                msg = (
+                    f"'{path}' is not present in the model files. "
+                    f"You can access the other files of the attached model at '{cached_path}'"
+                )
+                raise ValueError(msg)
+            return cached_filepath
+        return cached_path

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,3 +5,6 @@ os.environ["KAGGLE_CONFIG_DIR"] = "/some-missing-directory"
 
 # All APIs call in tests should go to a local test server.
 os.environ["KAGGLE_API_ENDPOINT"] = "http://localhost:7777"
+
+# All JWT handlers calls in tests should go to a local test server.
+os.environ["KAGGLE_URL_BASE"] = "http://localhost:7778"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,7 @@ from kagglehub.config import (
     CREDENTIALS_FILENAME,
     CREDENTIALS_FOLDER_ENV_VAR_NAME,
     DEFAULT_CACHE_FOLDER,
+    DISABLE_KAGGLE_CACHE_ENV_VAR_NAME,
     KAGGLE_API_ENDPOINT_ENV_VAR_NAME,
     KEY_ENV_VAR_NAME,
     LOG_VERBOSITY_ENV_VAR_NAME,
@@ -18,6 +19,7 @@ from kagglehub.config import (
     get_kaggle_api_endpoint,
     get_kaggle_credentials,
     get_log_verbosity,
+    is_kaggle_cache_disabled,
 )
 
 
@@ -111,3 +113,23 @@ class TestConfig(unittest.TestCase):
     @mock.patch.dict(os.environ, {LOG_VERBOSITY_ENV_VAR_NAME: "invalid"})
     def test_get_log_verbosity_environment_var_override_invalid_value_use_default(self):
         self.assertEqual(logging.INFO, get_log_verbosity())
+
+    def test_is_kaggle_cache_disabled_default(self):
+        # By default, the Kaggle cache is not disabled.
+        self.assertFalse(is_kaggle_cache_disabled())
+
+    def test_is_kaggle_cache_disabled(self):
+        cases = [
+            ("t", True),
+            ("1", True),
+            ("True", True),
+            ("true", True),
+            ("", False),
+            ("0", False),
+            ("False", False),
+            ("false", False),
+        ]
+        for t in cases:
+            env_var_value, expected = t[0], t[1]
+            with mock.patch.dict(os.environ, {DISABLE_KAGGLE_CACHE_ENV_VAR_NAME: env_var_value}):
+                self.assertEqual(expected, is_kaggle_cache_disabled())

--- a/tests/test_handle.py
+++ b/tests/test_handle.py
@@ -5,7 +5,8 @@ from kagglehub.handle import parse_model_handle
 
 class TestHandle(unittest.TestCase):
     def test_versioned_model_handle(self):
-        h = parse_model_handle("google/bert/tensorFlow2/answer-equivalence-bem/3")
+        handle = "google/bert/tensorFlow2/answer-equivalence-bem/3"
+        h = parse_model_handle(handle)
 
         self.assertEqual("google", h.owner)
         self.assertEqual("bert", h.model)
@@ -13,15 +14,18 @@ class TestHandle(unittest.TestCase):
         self.assertEqual("answer-equivalence-bem", h.variation)
         self.assertEqual(3, h.version)
         self.assertTrue(h.is_versioned())
+        self.assertEqual(handle, str(h))
 
     def test_unversioned_model_handle(self):
-        h = parse_model_handle("google/bert/tensorFlow2/answer-equivalence-bem")
+        handle = "google/bert/tensorFlow2/answer-equivalence-bem"
+        h = parse_model_handle(handle)
         self.assertEqual("google", h.owner)
         self.assertEqual("bert", h.model)
         self.assertEqual("tensorFlow2", h.framework)
         self.assertEqual("answer-equivalence-bem", h.variation)
         self.assertEqual(None, h.version)
         self.assertFalse(h.is_versioned())
+        self.assertEqual(handle, str(h))
 
     def test_invalid_model_handle(self):
         with self.assertRaises(ValueError):

--- a/tests/test_http_model_download.py
+++ b/tests/test_http_model_download.py
@@ -57,7 +57,8 @@ class KaggleAPIHandler(BaseHTTPRequestHandler):
             self.wfile.write(bytes(f"Unhandled path: {self.path}", "utf-8"))
 
 
-class TestModelDownload(unittest.TestCase):
+# Test cases for the HttpResolver.
+class TestHttpModelDownload(unittest.TestCase):
     def test_unversioned_model_download(self):
         with create_test_cache() as d:
             with create_test_http_server(KaggleAPIHandler):

--- a/tests/test_kaggle_cache_model_download.py
+++ b/tests/test_kaggle_cache_model_download.py
@@ -1,0 +1,108 @@
+import json
+import os
+import unittest
+from http.server import BaseHTTPRequestHandler
+from pathlib import Path
+
+import kagglehub
+from kagglehub.kaggle_cache_resolver import ATTACH_DATASOURCE_REQUEST_NAME, KAGGLE_CACHE_MOUNT_FOLDER_ENV_VAR_NAME
+
+from .utils import create_test_jwt_http_server
+
+INVALID_ARCHIVE_MODEL_HANDLE = "metaresearch/llama-2/pyTorch/bad-archive-variation/1"
+VERSIONED_MODEL_HANDLE = "metaresearch/llama-2/pyTorch/13b/1"
+LATEST_MODEL_VERSION = 2
+UNVERSIONED_MODEL_HANDLE = "metaresearch/llama-2/pyTorch/13b"
+TEST_FILEPATH = "config.json"
+
+
+class KaggleJwtHandler(BaseHTTPRequestHandler):
+    def do_HEAD(self):  # noqa: N802
+        self.send_response(200)
+
+    def do_POST(self):  # noqa: N802
+        if self.path.endswith(ATTACH_DATASOURCE_REQUEST_NAME):
+            content_length = int(self.headers["Content-Length"])
+            request = json.loads(self.rfile.read(content_length))
+            model_ref = request["modelRef"]
+            version_number = LATEST_MODEL_VERSION
+            if "VersionNumber" in model_ref:
+                version_number = model_ref["VersionNumber"]
+
+            mount_slug = (
+                f"{model_ref['ModelSlug']}/{model_ref['Framework']}/{model_ref['InstanceSlug']}/{version_number}"
+            )
+
+            self.send_response(200)
+            self.send_header("Content-type", "application/json")
+            self.end_headers()
+
+            # Load the files
+            cache_mount_folder = os.getenv(KAGGLE_CACHE_MOUNT_FOLDER_ENV_VAR_NAME)
+            base_path = f"{cache_mount_folder}/{mount_slug}"
+            os.makedirs(base_path, exist_ok=True)
+
+            Path(f"{base_path}/config.json").touch()
+
+            if version_number == LATEST_MODEL_VERSION:
+                # The latest version has an extra file.
+                Path(f"{base_path}/model.keras").touch()
+
+            # Return the response
+            self.wfile.write(
+                bytes(
+                    json.dumps(
+                        {
+                            "wasSuccessful": True,
+                            "result": {
+                                "mountSlug": mount_slug,
+                            },
+                        }
+                    ),
+                    "utf-8",
+                )
+            )
+        else:
+            self.send_response(404)
+            self.wfile.write(bytes(f"Unhandled path: {self.path}", "utf-8"))
+
+
+# Test cases for the KaggleCacheResolver.
+class TestKaggleCacheModelDownload(unittest.TestCase):
+    def test_unversioned_model_download(self):
+        with create_test_jwt_http_server(KaggleJwtHandler):
+            model_path = kagglehub.model_download(UNVERSIONED_MODEL_HANDLE)
+            self.assertTrue(model_path.endswith("/2"))
+            self.assertEqual(["config.json", "model.keras"], sorted(os.listdir(model_path)))
+
+    def test_versioned_model_download(self):
+        with create_test_jwt_http_server(KaggleJwtHandler):
+            model_path = kagglehub.model_download(VERSIONED_MODEL_HANDLE)
+            self.assertTrue(model_path.endswith("/1"))
+            self.assertEqual(["config.json"], sorted(os.listdir(model_path)))
+
+    def test_versioned_model_download_with_path(self):
+        with create_test_jwt_http_server(KaggleJwtHandler):
+            model_file_path = kagglehub.model_download(VERSIONED_MODEL_HANDLE, "config.json")
+            self.assertTrue(model_file_path.endswith("config.json"))
+            self.assertTrue(os.path.isfile(model_file_path))
+
+    def test_unversioned_model_download_with_path(self):
+        with create_test_jwt_http_server(KaggleJwtHandler):
+            model_file_path = kagglehub.model_download(UNVERSIONED_MODEL_HANDLE, "config.json")
+            self.assertTrue(model_file_path.endswith("config.json"))
+            self.assertTrue(os.path.isfile(model_file_path))
+
+    def test_versioned_model_download_with_missing_file_raises(self):
+        with create_test_jwt_http_server(KaggleJwtHandler):
+            with self.assertRaises(ValueError):
+                kagglehub.model_download(VERSIONED_MODEL_HANDLE, "missing.txt")
+
+    def test_unversioned_model_download_with_missing_file_raises(self):
+        with create_test_jwt_http_server(KaggleJwtHandler):
+            with self.assertRaises(ValueError):
+                kagglehub.model_download(UNVERSIONED_MODEL_HANDLE, "missing.txt")
+
+    def test_versioned_model_download_bad_handle_raises(self):
+        with self.assertRaises(ValueError):
+            kagglehub.model_download("bad handle")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,7 +8,9 @@ from typing import Type
 from unittest import mock
 from urllib.parse import urlparse
 
+from kagglehub.clients import KAGGLE_JWT_TOKEN_ENV_VAR_NAME, KAGGLE_URL_BASE_ENV_VAR_NAME
 from kagglehub.config import CACHE_FOLDER_ENV_VAR_NAME, KAGGLE_API_ENDPOINT_ENV_VAR_NAME
+from kagglehub.kaggle_cache_resolver import KAGGLE_CACHE_MOUNT_FOLDER_ENV_VAR_NAME, KAGGLE_NOTEBOOK_ENV_VAR_NAME
 
 
 def get_test_file_path(relative_path):
@@ -36,3 +38,28 @@ def create_test_http_server(handler_class: Type[BaseHTTPRequestHandler]):
             yield httpd
         finally:
             httpd.shutdown()
+
+
+@contextmanager
+def create_test_jwt_http_server(handler_class: Type[BaseHTTPRequestHandler]):
+    with TemporaryDirectory() as cache_mount_folder:
+        with mock.patch.dict(
+            os.environ,
+            {
+                KAGGLE_NOTEBOOK_ENV_VAR_NAME: "Interactive",
+                KAGGLE_JWT_TOKEN_ENV_VAR_NAME: "foo token",
+                KAGGLE_CACHE_MOUNT_FOLDER_ENV_VAR_NAME: cache_mount_folder,
+            },
+        ):
+            endpoint = os.getenv(KAGGLE_URL_BASE_ENV_VAR_NAME)
+            test_server_address = urlparse(endpoint)
+            if not test_server_address.hostname or not test_server_address.port:
+                msg = f"Invalid JWT test server address: {endpoint}. You must specify a hostname & port"
+                raise ValueError(msg)
+            with HTTPServer((test_server_address.hostname, test_server_address.port), handler_class) as httpd:
+                threading.Thread(target=httpd.serve_forever).start()
+
+                try:
+                    yield httpd
+                finally:
+                    httpd.shutdown()


### PR DESCRIPTION
If we detect we are inside a Kaggle notebook (via the `KAGGLE_KERNEL_RUN_TYPE` env variable), then we call the `AttachDatasourceUsingJwtHandler`.

Also, I added a `DISABLE_KAGGLE_CACHE` environment variable. If set to a truthy value, the KaggleCacheResolver will be skipped.

Next: Call `AttachDatasourceUsingJwtHandler` through the Data Proxy inside internet disabled sessions.

http://b/305947763