### PR TITLE
Increase timeout for AttachDatasourceUsingJwt

### DIFF
--- a/src/kagglehub/clients.py
+++ b/src/kagglehub/clients.py
@@ -129,7 +129,7 @@ class KaggleJwtClient:
         }
 
     def post(
-        self, request_name: str, data: dict, timeout: tuple[int, int] = (DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT)
+        self, request_name: str, data: dict, timeout: tuple = (DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT)
     ) -> dict:
         url = f"{self.endpoint}{KaggleJwtClient.BASE_PATH}{request_name}"
         with requests.post(

--- a/src/kagglehub/clients.py
+++ b/src/kagglehub/clients.py
@@ -128,13 +128,15 @@ class KaggleJwtClient:
             "X-KAGGLE-PROXY-DATA": data_proxy_token,
         }
 
-    def post(self, request_name: str, data: dict) -> dict:
+    def post(
+        self, request_name: str, data: dict, timeout: tuple[int, int] = (DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT)
+    ) -> dict:
         url = f"{self.endpoint}{KaggleJwtClient.BASE_PATH}{request_name}"
         with requests.post(
             url,
             headers=self.headers,
             data=bytes(json.dumps(data), "utf-8"),
-            timeout=(DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT),
+            timeout=timeout,
         ) as response:
             response.raise_for_status()
             json_response = response.json()

--- a/src/kagglehub/clients.py
+++ b/src/kagglehub/clients.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from typing import Tuple
 from urllib.parse import urljoin
 
 import requests
@@ -129,7 +130,10 @@ class KaggleJwtClient:
         }
 
     def post(
-        self, request_name: str, data: dict, timeout: tuple = (DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT)
+        self,
+        request_name: str,
+        data: dict,
+        timeout: Tuple[float, float] = (DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT),
     ) -> dict:
         url = f"{self.endpoint}{KaggleJwtClient.BASE_PATH}{request_name}"
         with requests.post(

--- a/src/kagglehub/kaggle_cache_resolver.py
+++ b/src/kagglehub/kaggle_cache_resolver.py
@@ -3,7 +3,7 @@ import os
 import time
 from typing import Optional
 
-from kagglehub.clients import KAGGLE_DATA_PROXY_URL_ENV_VAR_NAME, KaggleJwtClient
+from kagglehub.clients import DEFAULT_CONNECT_TIMEOUT, KAGGLE_DATA_PROXY_URL_ENV_VAR_NAME, KaggleJwtClient
 from kagglehub.config import is_kaggle_cache_disabled
 from kagglehub.exceptions import BackendError
 from kagglehub.handle import ModelHandle
@@ -12,6 +12,8 @@ from kagglehub.resolver import Resolver
 KAGGLE_NOTEBOOK_ENV_VAR_NAME = "KAGGLE_KERNEL_RUN_TYPE"
 KAGGLE_CACHE_MOUNT_FOLDER_ENV_VAR_NAME = "KAGGLE_CACHE_MOUNT_FOLDER"
 ATTACH_DATASOURCE_REQUEST_NAME = "AttachDatasourceUsingJwtRequest"
+# b/312965617: Using a longer timeout for this RPC.
+ATTACH_DATASOURCE_READ_TIMEOUT = 30  # seconds
 
 DEFAULT_KAGGLE_CACHE_MOUNT_FOLDER = "/kaggle/input"
 
@@ -54,6 +56,7 @@ class KaggleCacheResolver(Resolver):
             {
                 "modelRef": model_ref,
             },
+            timeout=(DEFAULT_CONNECT_TIMEOUT, ATTACH_DATASOURCE_READ_TIMEOUT),
         )
         if "mountSlug" not in result:
             msg = "'result.mountSlug' field missing from response"


### PR DESCRIPTION
AttachDatasourceUsingJwt calls UpdateKernelSession which then calls the session scheduler. The method on the scheduler may take up to 20s (after 20s, the work continues in the background). See b/312965617.

Setting the timeout for AttachDatasourceUsingJwt to 30s to leave a bit of buffer for the other logic around.

http://b/305947763