### PR TITLE
Fix notebook env detection logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 *
 
+## v0.1.2 (Nov 30th, 2023)
+
+* Fixed notebook environment detection logic ([#36](https://github.com/Kaggle/kagglehub/pull/36))
+
 ## v0.1.1 (Nov 30th, 2023)
 
 * Fixed login credential validation ([#33](https://github.com/Kaggle/kagglehub/pull/33), [#34](https://github.com/Kaggle/kagglehub/pull/34))

--- a/src/kagglehub/__init__.py
+++ b/src/kagglehub/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 import kagglehub.logging
 from kagglehub import http_resolver, kaggle_cache_resolver, registry

--- a/src/kagglehub/auth.py
+++ b/src/kagglehub/auth.py
@@ -42,8 +42,20 @@ def _capture_logger_output():
         logger.removeHandler(handler)
 
 
-def _is_in_notebook():
-    return "IPython" in sys.modules
+def _is_in_notebook() -> bool:
+    """Return `True` if code is executed in a notebook (Jupyter, Kaggle Notebook, Colab, QTconsole).
+
+    Taken from https://stackoverflow.com/a/39662359.
+    Adapted to make it work with Google colab as well.
+    """
+    try:
+        shell_class = get_ipython().__class__  # type: ignore # noqa: F821
+        for parent_class in shell_class.__mro__:  # e.g. "is subclass of"
+            if parent_class.__name__ == "ZMQInteractiveShell":
+                return True  # Jupyter notebook, Kaggle Noteboo, Google colab or qtconsole
+        return False
+    except NameError:
+        return False  # Probably standard Python interpreter
 
 
 def _notebook_login(validate_credentials) -> None:

--- a/src/kagglehub/auth.py
+++ b/src/kagglehub/auth.py
@@ -1,6 +1,5 @@
 import io
 import logging
-import sys
 from contextlib import contextmanager
 
 from kagglehub.clients import KaggleApiV1Client
@@ -49,12 +48,14 @@ def _is_in_notebook() -> bool:
     Adapted to make it work with Google colab as well.
     """
     try:
-        shell_class = get_ipython().__class__  # type: ignore # noqa: F821
+        from IPython import get_ipython  # type: ignore
+
+        shell_class = get_ipython().__class__
         for parent_class in shell_class.__mro__:  # e.g. "is subclass of"
             if parent_class.__name__ == "ZMQInteractiveShell":
                 return True  # Jupyter notebook, Kaggle Noteboo, Google colab or qtconsole
         return False
-    except NameError:
+    except (NameError, ModuleNotFoundError):
         return False  # Probably standard Python interpreter
 
 


### PR DESCRIPTION
Currently, calling `kagglehub.login()` in a IPython session would try to show a widget and fail: https://screenshot.googleplex.com/9vmyWNKDjymVuny

http://b/314205619