### PR TITLE
Improve log for Kaggle Cache Resolver.

### DIFF
--- a/src/kagglehub/kaggle_cache_resolver.py
+++ b/src/kagglehub/kaggle_cache_resolver.py
@@ -40,7 +40,10 @@ class KaggleCacheResolver(Resolver):
         return False
 
     def __call__(self, h: ModelHandle, path: Optional[str] = None) -> str:
-        logger.info(f"Attaching model '{h}' to your Kaggle notebook...")
+        if path:
+            logger.info(f"Attaching '{path}' from model '{h}' to your Kaggle notebook...")
+        else:
+            logger.info(f"Attaching model '{h}' to your Kaggle notebook...")
         client = KaggleJwtClient()
         model_ref = {
             "OwnerSlug": h.owner,
@@ -64,12 +67,13 @@ class KaggleCacheResolver(Resolver):
 
         base_mount_path = os.getenv(KAGGLE_CACHE_MOUNT_FOLDER_ENV_VAR_NAME, DEFAULT_KAGGLE_CACHE_MOUNT_FOLDER)
         cached_path = f"{base_mount_path}/{result['mountSlug']}"
+        
+        if not os.path.exists(cached_path):
+            # Only print this if the model is not already mounted.
+            logger.info(f"Mounting files to {cached_path}...")
 
-        logger.info(f"Mounting files to {cached_path}...")
-        while not os.path.exists(cached_path):
+        while not os.path.exists(cached_path):                
             time.sleep(5)
-
-        logger.info(f"Model '{h}' is attached.")
 
         if path:
             cached_filepath = f"{cached_path}/{path}"

--- a/src/kagglehub/kaggle_cache_resolver.py
+++ b/src/kagglehub/kaggle_cache_resolver.py
@@ -67,12 +67,12 @@ class KaggleCacheResolver(Resolver):
 
         base_mount_path = os.getenv(KAGGLE_CACHE_MOUNT_FOLDER_ENV_VAR_NAME, DEFAULT_KAGGLE_CACHE_MOUNT_FOLDER)
         cached_path = f"{base_mount_path}/{result['mountSlug']}"
-        
+
         if not os.path.exists(cached_path):
             # Only print this if the model is not already mounted.
             logger.info(f"Mounting files to {cached_path}...")
 
-        while not os.path.exists(cached_path):                
+        while not os.path.exists(cached_path):
             time.sleep(5)
 
         if path:


### PR DESCRIPTION
- Clarifiy whether the user is accessing a single file or the full model.
- Do not print "Mounting files ..." if the model is already mounted.
- Remove the "Model X is attached" at the end. The method returning the path is already enough. This is spammy.

The goal is to reduce the spammy log since Keras will be attaching several files.

- Before: https://screenshot.googleplex.com/4KvivYGDqVxCngc
- After: https://screenshot.googleplex.com/9YPyQG5oW5B87iS