### PR TITLE
Implement force_download option for model_download over HTTP

### DIFF
--- a/src/kagglehub/cache.py
+++ b/src/kagglehub/cache.py
@@ -1,6 +1,6 @@
 import os
-from pathlib import Path
 import shutil
+from pathlib import Path
 from typing import Optional, Union
 
 from kagglehub.config import get_cache_folder
@@ -57,7 +57,7 @@ def mark_as_incomplete(handle: Union[ModelHandle], path: Optional[str] = None):
         os.removedirs(os.path.dirname(marker_path))
 
 
-def delete_from_cache(handle: Union[ModelHandle], path: str) -> Optional[str]:
+def delete_from_cache(handle: Union[ModelHandle], path: Optional[str]) -> Optional[str]:
     """Delete resource from the cache, even if incomplete.
 
     Args:

--- a/src/kagglehub/cache.py
+++ b/src/kagglehub/cache.py
@@ -52,12 +52,12 @@ def mark_as_incomplete(handle: Union[ModelHandle], path: Optional[str] = None):
     marker_path = _get_completion_marker_filepath(handle, path)
     if os.path.exists(marker_path):
         os.remove(marker_path)
-    # Delete the parent directory if it's now empty.
-    if len(os.listdir(os.path.dirname(marker_path))) == 0:
-        os.removedirs(os.path.dirname(marker_path))
+        # Delete the parent directory if it's now empty.
+        if len(os.listdir(os.path.dirname(marker_path))) == 0:
+            os.removedirs(os.path.dirname(marker_path))
 
 
-def delete_from_cache(handle: Union[ModelHandle], path: Optional[str]) -> Optional[str]:
+def delete_from_cache(handle: Union[ModelHandle], path: Optional[str] = None) -> Optional[str]:
     """Delete resource from the cache, even if incomplete.
 
     Args:
@@ -70,8 +70,12 @@ def delete_from_cache(handle: Union[ModelHandle], path: Optional[str]) -> Option
     mark_as_incomplete(handle, path)
     model_full_path = get_cached_path(handle, path)
     if os.path.exists(model_full_path):
-        shutil.rmtree(model_full_path)
-        os.removedirs(os.path.dirname(model_full_path))
+        if path:
+            os.remove(model_full_path)
+        else:
+            shutil.rmtree(model_full_path)
+        if len(os.listdir(os.path.dirname(model_full_path))) == 0:
+            os.removedirs(os.path.dirname(model_full_path))
         return model_full_path
     return None
 

--- a/src/kagglehub/cache.py
+++ b/src/kagglehub/cache.py
@@ -69,8 +69,7 @@ def _delete_from_cache_folder(path):
 
 def mark_as_incomplete(handle: Union[ModelHandle], path: Optional[str] = None):
     marker_path = _get_completion_marker_filepath(handle, path)
-    if os.path.exists(marker_path):
-        _delete_from_cache_folder(marker_path)
+    _delete_from_cache_folder(marker_path)
 
 
 def delete_from_cache(handle: Union[ModelHandle], path: Optional[str] = None) -> Optional[str]:

--- a/src/kagglehub/cache.py
+++ b/src/kagglehub/cache.py
@@ -48,20 +48,24 @@ def mark_as_complete(handle: Union[ModelHandle], path: Optional[str] = None):
     Path(marker_path).touch()
 
 
-def delete_from_cache(handle: Union[ModelHandle], path: str) -> bool:
+def mark_as_incomplete(handle: Union[ModelHandle], path: Optional[str] = None):
     marker_path = _get_completion_marker_filepath(handle, path)
-    marker_dir = marker_path.rsplit("/", 1)[0]
+    if os.path.exists(marker_path):
+        os.remove(marker_path)
+    # Delete the parent directory if it's now empty.
+    if len(os.listdir(os.path.dirname(marker_path))) == 0:
+        os.removedirs(os.path.dirname(marker_path))
+
+
+def delete_from_cache(handle: Union[ModelHandle], path: str) -> bool:
+    mark_as_incomplete(handle, path)
     model_full_path = get_cached_path(handle, path)
-    model_dir = model_full_path.rsplit("/", 1)[0]
-    
-    os.remove(marker_path)
-    try:
-        os.removedirs(marker_dir)
-    except OSError:
-        pass # Directory might not be empty
-    shutil.rmtree(model_full_path)
-    os.removedirs(model_dir)
-    
+    if os.path.exists(model_full_path):
+        shutil.rmtree(model_full_path)
+        os.removedirs(os.path.dirname(model_full_path))
+        return True
+    return False
+
 
 def _get_completion_marker_filepath(handle: Union[ModelHandle], path: Optional[str] = None) -> str:
     # Can extend to add support for other resources like DatasetHandle.

--- a/src/kagglehub/cache.py
+++ b/src/kagglehub/cache.py
@@ -57,14 +57,23 @@ def mark_as_incomplete(handle: Union[ModelHandle], path: Optional[str] = None):
         os.removedirs(os.path.dirname(marker_path))
 
 
-def delete_from_cache(handle: Union[ModelHandle], path: str) -> bool:
+def delete_from_cache(handle: Union[ModelHandle], path: str) -> Optional[str]:
+    """Delete resource from the cache, even if incomplete.
+
+    Args:
+        handle: Resource handle
+        path: Optional path to a file within the bundle.
+
+    Returns:
+        A string representing the path of the deleted resource or None on cache miss.
+    """
     mark_as_incomplete(handle, path)
     model_full_path = get_cached_path(handle, path)
     if os.path.exists(model_full_path):
         shutil.rmtree(model_full_path)
         os.removedirs(os.path.dirname(model_full_path))
-        return True
-    return False
+        return model_full_path
+    return None
 
 
 def _get_completion_marker_filepath(handle: Union[ModelHandle], path: Optional[str] = None) -> str:

--- a/src/kagglehub/cache.py
+++ b/src/kagglehub/cache.py
@@ -56,8 +56,8 @@ def _delete_from_cache_folder(path):
         else:
             os.remove(path)
 
-        # Iterate through empty folders in the model path. Avoid using removedirs() because it may remove parents
-        # of the cache folder.
+        # Remove empty folders in the given path, up until the cache folder.
+        # Avoid using removedirs() because it may remove parents of the cache folder.
         curr_dir = os.path.dirname(path)
         while len(os.listdir(curr_dir)) == 0 and curr_dir != get_cache_folder():
             parent_dir = os.path.dirname(curr_dir)

--- a/src/kagglehub/cache.py
+++ b/src/kagglehub/cache.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+import shutil
 from typing import Optional, Union
 
 from kagglehub.config import get_cache_folder
@@ -46,6 +47,21 @@ def mark_as_complete(handle: Union[ModelHandle], path: Optional[str] = None):
     os.makedirs(os.path.dirname(marker_path), exist_ok=True)
     Path(marker_path).touch()
 
+
+def delete_from_cache(handle: Union[ModelHandle], path: str) -> bool:
+    marker_path = _get_completion_marker_filepath(handle, path)
+    marker_dir = marker_path.rsplit("/", 1)[0]
+    model_full_path = get_cached_path(handle, path)
+    model_dir = model_full_path.rsplit("/", 1)[0]
+    
+    os.remove(marker_path)
+    try:
+        os.removedirs(marker_dir)
+    except OSError:
+        pass # Directory might not be empty
+    shutil.rmtree(model_full_path)
+    os.removedirs(model_dir)
+    
 
 def _get_completion_marker_filepath(handle: Union[ModelHandle], path: Optional[str] = None) -> str:
     # Can extend to add support for other resources like DatasetHandle.

--- a/src/kagglehub/http_resolver.py
+++ b/src/kagglehub/http_resolver.py
@@ -15,16 +15,16 @@ class HttpResolver(Resolver):
         # Downloading files over HTTP is supported in all environments for all handles / path.
         return True
 
-    def __call__(self, h: ModelHandle, path: Optional[str] = None, force: Optional[bool] = False) -> str:
+    def __call__(self, h: ModelHandle, path: Optional[str] = None, force_download: Optional[bool] = False) -> str:
         api_client = KaggleApiV1Client()
 
         if not h.is_versioned():
             h.version = _get_current_version(api_client, h)
 
         model_path = load_from_cache(h, path)
-        if model_path and not force:
+        if model_path and not force_download:
             return model_path  # Already cached
-        elif model_path and force:
+        elif model_path and force_download:
             delete_from_cache(h, path)
             # Delete from cache
 

--- a/src/kagglehub/http_resolver.py
+++ b/src/kagglehub/http_resolver.py
@@ -17,7 +17,7 @@ MODEL_INSTANCE_VERSION_FIELD = "versionNumber"
 
 
 class HttpResolver(Resolver):
-    def is_supported(self, *_) -> bool:
+    def is_supported(self, *_, **__) -> bool:
         # Downloading files over HTTP is supported in all environments for all handles / path.
         return True
 

--- a/src/kagglehub/http_resolver.py
+++ b/src/kagglehub/http_resolver.py
@@ -2,7 +2,7 @@ import os
 import tarfile
 from typing import Optional
 
-from kagglehub.cache import get_cached_archive_path, get_cached_path, load_from_cache, mark_as_complete
+from kagglehub.cache import delete_from_cache, get_cached_archive_path, get_cached_path, load_from_cache, mark_as_complete
 from kagglehub.clients import KaggleApiV1Client
 from kagglehub.handle import ModelHandle
 from kagglehub.resolver import Resolver
@@ -15,15 +15,18 @@ class HttpResolver(Resolver):
         # Downloading files over HTTP is supported in all environments for all handles / path.
         return True
 
-    def __call__(self, h: ModelHandle, path: Optional[str] = None) -> str:
+    def __call__(self, h: ModelHandle, path: Optional[str] = None, force: Optional[bool] = False) -> str:
         api_client = KaggleApiV1Client()
 
         if not h.is_versioned():
             h.version = _get_current_version(api_client, h)
 
         model_path = load_from_cache(h, path)
-        if model_path:
+        if model_path and not force:
             return model_path  # Already cached
+        elif model_path and force:
+            delete_from_cache(h, path)
+            # Delete from cache
 
         url_path = _build_download_url_path(h)
         out_path = get_cached_path(h, path)

--- a/src/kagglehub/http_resolver.py
+++ b/src/kagglehub/http_resolver.py
@@ -2,7 +2,13 @@ import os
 import tarfile
 from typing import Optional
 
-from kagglehub.cache import delete_from_cache, get_cached_archive_path, get_cached_path, load_from_cache, mark_as_complete
+from kagglehub.cache import (
+    delete_from_cache,
+    get_cached_archive_path,
+    get_cached_path,
+    load_from_cache,
+    mark_as_complete,
+)
 from kagglehub.clients import KaggleApiV1Client
 from kagglehub.handle import ModelHandle
 from kagglehub.resolver import Resolver
@@ -15,7 +21,7 @@ class HttpResolver(Resolver):
         # Downloading files over HTTP is supported in all environments for all handles / path.
         return True
 
-    def __call__(self, h: ModelHandle, path: Optional[str] = None, force_download: Optional[bool] = False) -> str:
+    def __call__(self, h: ModelHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False) -> str:
         api_client = KaggleApiV1Client()
 
         if not h.is_versioned():
@@ -26,7 +32,6 @@ class HttpResolver(Resolver):
             return model_path  # Already cached
         elif model_path and force_download:
             delete_from_cache(h, path)
-            # Delete from cache
 
         url_path = _build_download_url_path(h)
         out_path = get_cached_path(h, path)

--- a/src/kagglehub/kaggle_cache_resolver.py
+++ b/src/kagglehub/kaggle_cache_resolver.py
@@ -39,8 +39,8 @@ class KaggleCacheResolver(Resolver):
 
         return False
 
-    def __call__(self, h: ModelHandle, path: Optional[str] = None, force: Optional[bool] = False) -> str:
-        if force:
+    def __call__(self, h: ModelHandle, path: Optional[str] = None, force_download: Optional[bool] = False) -> str:
+        if force_download:
             msg = "Invalid input: Cannot force download in a Kaggle notebook"
             raise ValueError(msg) from err
         

--- a/src/kagglehub/kaggle_cache_resolver.py
+++ b/src/kagglehub/kaggle_cache_resolver.py
@@ -41,8 +41,7 @@ class KaggleCacheResolver(Resolver):
 
     def __call__(self, h: ModelHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False) -> str:
         if force_download:
-            msg = "Invalid input: Cannot force download in a Kaggle notebook"
-            raise ValueError(msg)
+            logger.warning("Ignoring invalid input: force_download flag cannot be used in a Kaggle notebook")
 
         if path:
             logger.info(f"Attaching '{path}' from model '{h}' to your Kaggle notebook...")

--- a/src/kagglehub/kaggle_cache_resolver.py
+++ b/src/kagglehub/kaggle_cache_resolver.py
@@ -39,11 +39,11 @@ class KaggleCacheResolver(Resolver):
 
         return False
 
-    def __call__(self, h: ModelHandle, path: Optional[str] = None, force_download: Optional[bool] = False) -> str:
+    def __call__(self, h: ModelHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False) -> str:
         if force_download:
             msg = "Invalid input: Cannot force download in a Kaggle notebook"
-            raise ValueError(msg) from err
-        
+            raise ValueError(msg)
+
         if path:
             logger.info(f"Attaching '{path}' from model '{h}' to your Kaggle notebook...")
         else:

--- a/src/kagglehub/kaggle_cache_resolver.py
+++ b/src/kagglehub/kaggle_cache_resolver.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 class KaggleCacheResolver(Resolver):
-    def is_supported(self, *_) -> bool:
+    def is_supported(self, *_, **__) -> bool:
         if is_kaggle_cache_disabled():
             return False
 

--- a/src/kagglehub/kaggle_cache_resolver.py
+++ b/src/kagglehub/kaggle_cache_resolver.py
@@ -39,7 +39,11 @@ class KaggleCacheResolver(Resolver):
 
         return False
 
-    def __call__(self, h: ModelHandle, path: Optional[str] = None) -> str:
+    def __call__(self, h: ModelHandle, path: Optional[str] = None, force: Optional[bool] = False) -> str:
+        if force:
+            msg = "Invalid input: Cannot force download in a Kaggle notebook"
+            raise ValueError(msg) from err
+        
         if path:
             logger.info(f"Attaching '{path}' from model '{h}' to your Kaggle notebook...")
         else:

--- a/src/kagglehub/models.py
+++ b/src/kagglehub/models.py
@@ -4,7 +4,7 @@ from kagglehub import registry
 from kagglehub.handle import parse_model_handle
 
 
-def model_download(handle: str, path: Optional[str] = None, force_download: Optional[bool] = False):
+def model_download(handle: str, path: Optional[str] = None, *, force_download: Optional[bool] = False):
     """Download model files.
 
     Args:

--- a/src/kagglehub/models.py
+++ b/src/kagglehub/models.py
@@ -17,7 +17,7 @@ def model_download(handle: str, path: Optional[str] = None, force_download: Opti
         A string representing the path to the requested model files.
     """
     h = parse_model_handle(handle)
-    return registry.resolver(h, path, force)
+    return registry.resolver(h, path, force_download)
 
 
 def model_upload():

--- a/src/kagglehub/models.py
+++ b/src/kagglehub/models.py
@@ -4,18 +4,20 @@ from kagglehub import registry
 from kagglehub.handle import parse_model_handle
 
 
-def model_download(handle: str, path: Optional[str] = None):
+def model_download(handle: str, path: Optional[str] = None, force: Optional[bool] = False):
     """Download model files.
 
     Args:
         handle: (string) the model handle.
         path: (string) Optional path to a file within the model bundle.
+        force: (bool) Optional flag to force download a model, even if it's cached.
+
 
     Returns:
         A string representing the path to the requested model files.
     """
     h = parse_model_handle(handle)
-    return registry.resolver(h, path)
+    return registry.resolver(h, path, force)
 
 
 def model_upload():

--- a/src/kagglehub/models.py
+++ b/src/kagglehub/models.py
@@ -4,13 +4,13 @@ from kagglehub import registry
 from kagglehub.handle import parse_model_handle
 
 
-def model_download(handle: str, path: Optional[str] = None, force: Optional[bool] = False):
+def model_download(handle: str, path: Optional[str] = None, force_download: Optional[bool] = False):
     """Download model files.
 
     Args:
         handle: (string) the model handle.
         path: (string) Optional path to a file within the model bundle.
-        force: (bool) Optional flag to force download a model, even if it's cached.
+        force_download: (bool) Optional flag to force download a model, even if it's cached.
 
 
     Returns:

--- a/src/kagglehub/models.py
+++ b/src/kagglehub/models.py
@@ -17,7 +17,7 @@ def model_download(handle: str, path: Optional[str] = None, *, force_download: O
         A string representing the path to the requested model files.
     """
     h = parse_model_handle(handle)
-    return registry.resolver(h, path, force_download)
+    return registry.resolver(h, path, force_download=force_download)
 
 
 def model_upload():

--- a/src/kagglehub/resolver.py
+++ b/src/kagglehub/resolver.py
@@ -10,13 +10,13 @@ class Resolver:
     __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
-    def __call__(self, handle: ModelHandle, path: Optional[str] = None, force: Optional[bool] = False) -> str:
+    def __call__(self, handle: ModelHandle, path: Optional[str] = None, force_download: Optional[bool] = False) -> str:
         """Resolves a handle into a path with the requested model files.
 
         Args:
             handle: (string) the model handle to resolve.
             path: (string) Optional path to a file within the model bundle.
-            force: (bool) Optional flag to force download a model, even if it's cached.
+            force_download: (bool) Optional flag to force download a model, even if it's cached.
 
 
         Returns:

--- a/src/kagglehub/resolver.py
+++ b/src/kagglehub/resolver.py
@@ -10,7 +10,9 @@ class Resolver:
     __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
-    def __call__(self, handle: ModelHandle, path: Optional[str] = None, force_download: Optional[bool] = False) -> str:
+    def __call__(
+        self, handle: ModelHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False
+    ) -> str:
         """Resolves a handle into a path with the requested model files.
 
         Args:

--- a/src/kagglehub/resolver.py
+++ b/src/kagglehub/resolver.py
@@ -10,12 +10,13 @@ class Resolver:
     __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
-    def __call__(self, handle: ModelHandle, path: Optional[str] = None) -> str:
+    def __call__(self, handle: ModelHandle, path: Optional[str] = None, force: Optional[bool] = False) -> str:
         """Resolves a handle into a path with the requested model files.
 
         Args:
             handle: (string) the model handle to resolve.
             path: (string) Optional path to a file within the model bundle.
+            force: (bool) Optional flag to force download a model, even if it's cached.
 
 
         Returns:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -26,13 +26,13 @@ TEST_FILEPATH = "foo.txt"
 
 class TestCache(BaseTestCase):
     def test_load_from_cache_miss(self):
-#         ModelHandle(
-#             owner="google",
-#             model="bert",
-#             framework="tensorFlow2",
-#             variation="answer-equivalence-bem",
-#             version=2,
-#         )
+        #         ModelHandle(
+        #             owner="google",
+        #             model="bert",
+        #             framework="tensorFlow2",
+        #             variation="answer-equivalence-bem",
+        #             version=2,
+        #         )
         self.assertEqual(None, load_from_cache(TEST_MODEL_HANDLE))
 
     def test_load_from_cache_with_path_miss(self):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -15,12 +15,7 @@ from tests.fixtures import BaseTestCase
 from .utils import create_test_cache
 
 EXPECTED_MODEL_SUBDIR = os.path.join(
-    MODELS_CACHE_SUBFOLDER,
-    "google",
-    "bert",
-    "tensorFlow2",
-    "answer-equivalence-bem",
-    "2"
+    MODELS_CACHE_SUBFOLDER, "google", "bert", "tensorFlow2", "answer-equivalence-bem", "2"
 )
 
 EXPECTED_MODEL_SUBPATH = os.path.join(

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -41,13 +41,14 @@ TEST_FILEPATH = "foo.txt"
 
 class TestCache(BaseTestCase):
     def test_load_from_cache_miss(self):
-        #         ModelHandle(
-        #             owner="google",
-        #             model="bert",
-        #             framework="tensorFlow2",
-        #             variation="answer-equivalence-bem",
-        #             version=2,
-        #         )
+        # Why is this ModelHandle needed?
+        ModelHandle(
+            owner="google",
+            model="bert",
+            framework="tensorFlow2",
+            variation="answer-equivalence-bem",
+            version=2,
+        )
         self.assertEqual(None, load_from_cache(TEST_MODEL_HANDLE))
 
     def test_load_from_cache_with_path_miss(self):
@@ -183,7 +184,7 @@ class TestCache(BaseTestCase):
 
             deleted_path = delete_from_cache(TEST_MODEL_HANDLE)
 
-            # Should not have deleted anything if only the marker file existed.
+            # Should not delete anything if only the marker file existed.
             self.assertEqual(None, deleted_path)
 
     def test_delete_from_cache_without_files_with_complete_marker_with_path(self):
@@ -192,7 +193,7 @@ class TestCache(BaseTestCase):
 
             deleted_path = delete_from_cache(TEST_MODEL_HANDLE, path=TEST_FILEPATH)
 
-            # Should not have deleted anything if only the marker file existed.
+            # Should not delete anything if only the marker file existed.
             self.assertEqual(None, deleted_path)
 
     def test_delete_from_cache_with_files_without_complete_marker(self):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -26,13 +26,13 @@ TEST_FILEPATH = "foo.txt"
 
 class TestCache(BaseTestCase):
     def test_load_from_cache_miss(self):
-        ModelHandle(
-            owner="google",
-            model="bert",
-            framework="tensorFlow2",
-            variation="answer-equivalence-bem",
-            version=2,
-        )
+#         ModelHandle(
+#             owner="google",
+#             model="bert",
+#             framework="tensorFlow2",
+#             variation="answer-equivalence-bem",
+#             version=2,
+#         )
         self.assertEqual(None, load_from_cache(TEST_MODEL_HANDLE))
 
     def test_load_from_cache_with_path_miss(self):
@@ -51,7 +51,7 @@ class TestCache(BaseTestCase):
         with create_test_cache():
             cache_path = get_cached_path(TEST_MODEL_HANDLE)
 
-            # Should be a cache `miss` if the directory exists but not the marker file.
+            # Should be a cache `miss` if the directory and file exist but not the marker file.
             os.makedirs(cache_path)
             Path(os.path.join(cache_path, TEST_FILEPATH)).touch()  # Create file
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -203,6 +203,7 @@ class TestCache(BaseTestCase):
             deleted_path = delete_from_cache(TEST_MODEL_HANDLE)
 
             self.assertEqual(os.path.join(d, EXPECTED_MODEL_SUBDIR), deleted_path)
+            self.assertFalse(os.path.exists(get_cached_path(TEST_MODEL_HANDLE)))
 
     def test_delete_from_cache_with_files_without_complete_marker_with_path(self):
         with create_test_cache() as d:
@@ -212,3 +213,4 @@ class TestCache(BaseTestCase):
             deleted_path = delete_from_cache(TEST_MODEL_HANDLE, path=TEST_FILEPATH)
 
             self.assertEqual(os.path.join(d, EXPECTED_MODEL_SUBPATH), deleted_path)
+            self.assertFalse(os.path.exists(os.path.join(get_cached_path(TEST_MODEL_HANDLE), TEST_FILEPATH)))

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from kagglehub.cache import (
     MODELS_CACHE_SUBFOLDER,
+    delete_from_cache,
     get_cached_archive_path,
     get_cached_path,
     load_from_cache,
@@ -12,6 +13,25 @@ from kagglehub.handle import ModelHandle
 from tests.fixtures import BaseTestCase
 
 from .utils import create_test_cache
+
+EXPECTED_MODEL_SUBDIR = os.path.join(
+    MODELS_CACHE_SUBFOLDER,
+    "google",
+    "bert",
+    "tensorFlow2",
+    "answer-equivalence-bem",
+    "2"
+)
+
+EXPECTED_MODEL_SUBPATH = os.path.join(
+    MODELS_CACHE_SUBFOLDER,
+    "google",
+    "bert",
+    "tensorFlow2",
+    "answer-equivalence-bem",
+    "2",
+    "foo.txt",
+)
 
 TEST_MODEL_HANDLE = ModelHandle(
     owner="google",
@@ -59,6 +79,7 @@ class TestCache(BaseTestCase):
 
     def test_load_from_cache_with_complete_marker_no_files_miss(self):
         with create_test_cache():
+            # Why is this line needed?
             get_cached_path(TEST_MODEL_HANDLE)
 
             # Should be a cache `miss` if completion marker file exists but not the files themselves.
@@ -84,7 +105,7 @@ class TestCache(BaseTestCase):
             path = load_from_cache(TEST_MODEL_HANDLE)
 
             self.assertEqual(
-                os.path.join(d, MODELS_CACHE_SUBFOLDER, "google", "bert", "tensorFlow2", "answer-equivalence-bem", "2"),
+                os.path.join(d, EXPECTED_MODEL_SUBDIR),
                 path,
             )
 
@@ -99,16 +120,7 @@ class TestCache(BaseTestCase):
             path = load_from_cache(TEST_MODEL_HANDLE, path=TEST_FILEPATH)
 
             self.assertEqual(
-                os.path.join(
-                    d,
-                    MODELS_CACHE_SUBFOLDER,
-                    "google",
-                    "bert",
-                    "tensorFlow2",
-                    "answer-equivalence-bem",
-                    "2",
-                    "foo.txt",
-                ),
+                os.path.join(d, EXPECTED_MODEL_SUBPATH),
                 path,
             )
 
@@ -131,4 +143,84 @@ class TestCache(BaseTestCase):
                     "2.archive",
                 ),
                 archive_path,
+            )
+
+    def test_delete_from_cache(self):
+        with create_test_cache() as d:
+            cache_path = get_cached_path(TEST_MODEL_HANDLE)
+            os.makedirs(cache_path)
+            mark_as_complete(TEST_MODEL_HANDLE)
+
+            deleted_path = delete_from_cache(TEST_MODEL_HANDLE)
+
+            self.assertEqual(
+                os.path.join(d, EXPECTED_MODEL_SUBDIR),
+                deleted_path,
+            )
+
+    def test_delete_from_cache_with_path(self):
+        with create_test_cache() as d:
+            cache_path = get_cached_path(TEST_MODEL_HANDLE)
+            os.makedirs(cache_path)
+            Path(os.path.join(cache_path, TEST_FILEPATH)).touch()  # Create file
+            mark_as_complete(TEST_MODEL_HANDLE, path=TEST_FILEPATH)
+
+            deleted_path = delete_from_cache(TEST_MODEL_HANDLE, path=TEST_FILEPATH)
+
+            self.assertEqual(
+                os.path.join(d, EXPECTED_MODEL_SUBPATH),
+                deleted_path,
+            )
+
+    def test_delete_from_cache_without_files_without_complete_marker(self):
+        with create_test_cache():
+            deleted_path = delete_from_cache(TEST_MODEL_HANDLE)
+            self.assertEqual(None, deleted_path)
+
+    def test_delete_from_cache_without_files_without_complete_marker_with_path(self):
+        with create_test_cache():
+            deleted_path = delete_from_cache(TEST_MODEL_HANDLE, path=TEST_FILEPATH)
+            self.assertEqual(None, deleted_path)
+
+    def test_delete_from_cache_without_files_with_complete_marker(self):
+        with create_test_cache():
+            mark_as_complete(TEST_MODEL_HANDLE)
+
+            deleted_path = delete_from_cache(TEST_MODEL_HANDLE)
+
+            # Should not have deleted anything if only the marker file existed.
+            self.assertEqual(None, deleted_path)
+
+    def test_delete_from_cache_without_files_with_complete_marker_with_path(self):
+        with create_test_cache():
+            mark_as_complete(TEST_MODEL_HANDLE, path=TEST_FILEPATH)
+
+            deleted_path = delete_from_cache(TEST_MODEL_HANDLE, path=TEST_FILEPATH)
+
+            # Should not have deleted anything if only the marker file existed.
+            self.assertEqual(None, deleted_path)
+
+    def test_delete_from_cache_with_files_without_complete_marker(self):
+        with create_test_cache() as d:
+            cache_path = get_cached_path(TEST_MODEL_HANDLE)
+            os.makedirs(cache_path)
+
+            deleted_path = delete_from_cache(TEST_MODEL_HANDLE)
+
+            self.assertEqual(
+                os.path.join(d, EXPECTED_MODEL_SUBDIR),
+                deleted_path,
+            )
+
+    def test_delete_from_cache_with_files_without_complete_marker_with_path(self):
+        with create_test_cache() as d:
+            cache_path = get_cached_path(TEST_MODEL_HANDLE)
+            os.makedirs(cache_path)
+            Path(os.path.join(cache_path, TEST_FILEPATH)).touch()  # Create file
+
+            deleted_path = delete_from_cache(TEST_MODEL_HANDLE, path=TEST_FILEPATH)
+
+            self.assertEqual(
+                os.path.join(d, EXPECTED_MODEL_SUBPATH),
+                deleted_path,
             )

--- a/tests/test_http_model_download.py
+++ b/tests/test_http_model_download.py
@@ -121,7 +121,7 @@ class TestHttpModelDownload(BaseTestCase):
     def test_unversioned_model_full_download_with_file_already_cached(self):
         with create_test_cache() as d:
             with create_test_http_server(KaggleAPIHandler):
-                # Download a single file
+                # Download a single file first
                 kagglehub.model_download(UNVERSIONED_MODEL_HANDLE, path=TEST_FILEPATH)
                 self._download_model_and_assert_downloaded(d, UNVERSIONED_MODEL_HANDLE, EXPECTED_MODEL_SUBDIR)
 
@@ -151,7 +151,7 @@ class TestHttpModelDownload(BaseTestCase):
     def test_unversioned_model_full_download_with_file_already_cached_and_force_download(self):
         with create_test_cache() as d:
             with create_test_http_server(KaggleAPIHandler):
-                # Download a single file
+                # Download a single file first
                 kagglehub.model_download(UNVERSIONED_MODEL_HANDLE, path=TEST_FILEPATH)
                 self._download_model_and_assert_downloaded(
                     d, UNVERSIONED_MODEL_HANDLE, EXPECTED_MODEL_SUBDIR, force_download=True

--- a/tests/test_http_model_download.py
+++ b/tests/test_http_model_download.py
@@ -3,6 +3,8 @@ import json
 import os
 from http.server import BaseHTTPRequestHandler
 
+import requests
+
 import kagglehub
 from kagglehub.cache import MODELS_CACHE_SUBFOLDER, get_cached_archive_path
 from kagglehub.handle import parse_model_handle
@@ -16,6 +18,7 @@ INVALID_ARCHIVE_MODEL_HANDLE = "metaresearch/llama-2/pyTorch/bad-archive-variati
 VERSIONED_MODEL_HANDLE = "metaresearch/llama-2/pyTorch/13b/3"
 UNVERSIONED_MODEL_HANDLE = "metaresearch/llama-2/pyTorch/13b"
 TEST_FILEPATH = "config.json"
+TEST_CONTENTS = "{}"
 
 
 class KaggleAPIHandler(BaseHTTPRequestHandler):
@@ -68,63 +71,91 @@ class KaggleAPIHandler(BaseHTTPRequestHandler):
             self.wfile.write(bytes(f"Unhandled path: {self.path}", "utf-8"))
 
 
+EXPECTED_MODEL_SUBDIR = os.path.join(MODELS_CACHE_SUBFOLDER, "metaresearch", "llama-2", "pyTorch", "13b", "3")
+EXPECTED_MODEL_SUBPATH = os.path.join(
+    MODELS_CACHE_SUBFOLDER,
+    "metaresearch",
+    "llama-2",
+    "pyTorch",
+    "13b",
+    "3",
+    TEST_FILEPATH,
+)
+
+
 # Test cases for the HttpResolver.
 class TestHttpModelDownload(BaseTestCase):
+    def _download_model_and_assert_downloaded(self, d, model_handle, expected_subdir_or_subpath, **kwargs):
+        # Download the full model and ensure all files are there.
+        model_path = kagglehub.model_download(model_handle, **kwargs)
+        self.assertEqual(os.path.join(d, expected_subdir_or_subpath), model_path)
+        self.assertEqual(["config.json", "model.keras"], sorted(os.listdir(model_path)))
+
+        # Assert that the archive file has been deleted.
+        archive_path = get_cached_archive_path(parse_model_handle(model_handle))
+        self.assertFalse(os.path.exists(archive_path))
+
+    def _download_test_file_and_assert_downloaded(self, d, model_handle, **kwargs):
+        model_path = kagglehub.model_download(model_handle, path=TEST_FILEPATH, **kwargs)
+        self.assertEqual(os.path.join(d, EXPECTED_MODEL_SUBPATH), model_path)
+        with open(model_path) as model_file:
+            self.assertEqual(TEST_CONTENTS, model_file.readline())
+
     def test_unversioned_model_download(self):
         with create_test_cache() as d:
             with create_test_http_server(KaggleAPIHandler):
-                model_path = kagglehub.model_download(UNVERSIONED_MODEL_HANDLE)
-                self.assertEqual(
-                    os.path.join(d, MODELS_CACHE_SUBFOLDER, "metaresearch", "llama-2", "pyTorch", "13b", "3"),
-                    model_path,
-                )
-                self.assertEqual(["config.json", "model.keras"], sorted(os.listdir(model_path)))
-
-                # Assert that the archive file has been deleted.
-                archive_path = get_cached_archive_path(parse_model_handle(UNVERSIONED_MODEL_HANDLE))
-                self.assertFalse(os.path.exists(archive_path))
+                self._download_model_and_assert_downloaded(d, UNVERSIONED_MODEL_HANDLE, EXPECTED_MODEL_SUBDIR)
 
     def test_versioned_model_download(self):
         with create_test_cache() as d:
             with create_test_http_server(KaggleAPIHandler):
-                model_path = kagglehub.model_download(VERSIONED_MODEL_HANDLE)
-                self.assertEqual(
-                    os.path.join(d, MODELS_CACHE_SUBFOLDER, "metaresearch", "llama-2", "pyTorch", "13b", "3"),
-                    model_path,
-                )
-                self.assertEqual(["config.json", "model.keras"], sorted(os.listdir(model_path)))
-
-                # Assert that the archive file has been deleted.
-                archive_path = get_cached_archive_path(parse_model_handle(VERSIONED_MODEL_HANDLE))
-                self.assertFalse(os.path.exists(archive_path))
+                self._download_model_and_assert_downloaded(d, VERSIONED_MODEL_HANDLE, EXPECTED_MODEL_SUBDIR)
 
     def test_versioned_model_full_download_with_file_already_cached(self):
         with create_test_cache() as d:
             with create_test_http_server(KaggleAPIHandler):
-                # Download a single file
+                # Download a single file first
                 kagglehub.model_download(VERSIONED_MODEL_HANDLE, path=TEST_FILEPATH)
-                # Then download the full model and ensure all files are there.
-                model_path = kagglehub.model_download(VERSIONED_MODEL_HANDLE)
-
-                self.assertEqual(
-                    os.path.join(d, MODELS_CACHE_SUBFOLDER, "metaresearch", "llama-2", "pyTorch", "13b", "3"),
-                    model_path,
-                )
-                self.assertEqual(["config.json", "model.keras"], sorted(os.listdir(model_path)))
+                self._download_model_and_assert_downloaded(d, VERSIONED_MODEL_HANDLE, EXPECTED_MODEL_SUBDIR)
 
     def test_unversioned_model_full_download_with_file_already_cached(self):
         with create_test_cache() as d:
             with create_test_http_server(KaggleAPIHandler):
                 # Download a single file
                 kagglehub.model_download(UNVERSIONED_MODEL_HANDLE, path=TEST_FILEPATH)
-                # Then download the full model and ensure all files are there.
-                model_path = kagglehub.model_download(UNVERSIONED_MODEL_HANDLE)
+                self._download_model_and_assert_downloaded(d, UNVERSIONED_MODEL_HANDLE, EXPECTED_MODEL_SUBDIR)
 
-                self.assertEqual(
-                    os.path.join(d, MODELS_CACHE_SUBFOLDER, "metaresearch", "llama-2", "pyTorch", "13b", "3"),
-                    model_path,
+    def test_unversioned_model_download_with_force_download(self):
+        with create_test_cache() as d:
+            with create_test_http_server(KaggleAPIHandler):
+                self._download_model_and_assert_downloaded(
+                    d, UNVERSIONED_MODEL_HANDLE, EXPECTED_MODEL_SUBDIR, force_download=True
                 )
-                self.assertEqual(["config.json", "model.keras"], sorted(os.listdir(model_path)))
+
+    def test_versioned_model_download_with_force_download(self):
+        with create_test_cache() as d:
+            with create_test_http_server(KaggleAPIHandler):
+                self._download_model_and_assert_downloaded(
+                    d, VERSIONED_MODEL_HANDLE, EXPECTED_MODEL_SUBDIR, force_download=True
+                )
+
+    def test_versioned_model_full_download_with_file_already_cached_and_force_download(self):
+        with create_test_cache() as d:
+            with create_test_http_server(KaggleAPIHandler):
+                # Download a single file first
+                kagglehub.model_download(VERSIONED_MODEL_HANDLE, path=TEST_FILEPATH)
+                self._download_model_and_assert_downloaded(
+                    d, VERSIONED_MODEL_HANDLE, EXPECTED_MODEL_SUBDIR, force_download=True
+                )
+
+    def test_unversioned_model_full_download_with_file_already_cached_and_force_download(self):
+        with create_test_cache() as d:
+            with create_test_http_server(KaggleAPIHandler):
+                # Download a single file
+                kagglehub.model_download(UNVERSIONED_MODEL_HANDLE, path=TEST_FILEPATH)
+                self._download_model_and_assert_downloaded(
+                    d, UNVERSIONED_MODEL_HANDLE, EXPECTED_MODEL_SUBDIR, force_download=True
+                )
 
     def test_versioned_model_download_bad_archive(self):
         with create_test_cache():
@@ -135,42 +166,22 @@ class TestHttpModelDownload(BaseTestCase):
     def test_versioned_model_download_with_path(self):
         with create_test_cache() as d:
             with create_test_http_server(KaggleAPIHandler):
-                model_path = kagglehub.model_download(VERSIONED_MODEL_HANDLE, path=TEST_FILEPATH)
-                self.assertEqual(
-                    os.path.join(
-                        d,
-                        MODELS_CACHE_SUBFOLDER,
-                        "metaresearch",
-                        "llama-2",
-                        "pyTorch",
-                        "13b",
-                        "3",
-                        TEST_FILEPATH,
-                    ),
-                    model_path,
-                )
-                with open(model_path) as model_file:
-                    self.assertEqual("{}", model_file.readline())
+                self._download_test_file_and_assert_downloaded(d, VERSIONED_MODEL_HANDLE)
 
     def test_unversioned_model_download_with_path(self):
         with create_test_cache() as d:
             with create_test_http_server(KaggleAPIHandler):
-                model_path = kagglehub.model_download(UNVERSIONED_MODEL_HANDLE, path=TEST_FILEPATH)
-                self.assertEqual(
-                    os.path.join(
-                        d,
-                        MODELS_CACHE_SUBFOLDER,
-                        "metaresearch",
-                        "llama-2",
-                        "pyTorch",
-                        "13b",
-                        "3",
-                        TEST_FILEPATH,
-                    ),
-                    model_path,
-                )
-                with open(model_path) as model_file:
-                    self.assertEqual("{}", model_file.readline())
+                self._download_test_file_and_assert_downloaded(d, UNVERSIONED_MODEL_HANDLE)
+
+    def test_versioned_model_download_with_path_with_force_download(self):
+        with create_test_cache() as d:
+            with create_test_http_server(KaggleAPIHandler):
+                self._download_test_file_and_assert_downloaded(d, VERSIONED_MODEL_HANDLE, force_download=True)
+
+    def test_unversioned_model_download_with_path_with_force_download(self):
+        with create_test_cache() as d:
+            with create_test_http_server(KaggleAPIHandler):
+                self._download_test_file_and_assert_downloaded(d, UNVERSIONED_MODEL_HANDLE, force_download=True)
 
     def test_versioned_model_download_already_cached(self):
         with create_test_cache() as d:
@@ -181,10 +192,7 @@ class TestHttpModelDownload(BaseTestCase):
             # No internet, cache hit.
             model_path = kagglehub.model_download(VERSIONED_MODEL_HANDLE)
 
-            self.assertEqual(
-                os.path.join(d, MODELS_CACHE_SUBFOLDER, "metaresearch", "llama-2", "pyTorch", "13b", "3"),
-                model_path,
-            )
+            self.assertEqual(os.path.join(d, EXPECTED_MODEL_SUBDIR), model_path)
 
     def test_versioned_model_download_with_path_already_cached(self):
         with create_test_cache() as d:
@@ -194,9 +202,42 @@ class TestHttpModelDownload(BaseTestCase):
             # No internet, cache hit.
             model_path = kagglehub.model_download(VERSIONED_MODEL_HANDLE, path=TEST_FILEPATH)
 
-            self.assertEqual(
-                os.path.join(
-                    d, MODELS_CACHE_SUBFOLDER, "metaresearch", "llama-2", "pyTorch", "13b", "3", TEST_FILEPATH
-                ),
-                model_path,
-            )
+            self.assertEqual(os.path.join(d, EXPECTED_MODEL_SUBPATH), model_path)
+
+    def test_versioned_model_download_already_cached_with_force_download(self):
+        with create_test_cache():
+            with create_test_http_server(KaggleAPIHandler):
+                kagglehub.model_download(VERSIONED_MODEL_HANDLE)
+
+            # No internet should throw an error.
+            with self.assertRaises(requests.exceptions.ConnectionError):
+                kagglehub.model_download(VERSIONED_MODEL_HANDLE, force_download=True)
+
+    def test_versioned_model_download_with_path_already_cached_with_force_download(self):
+        with create_test_cache():
+            with create_test_http_server(KaggleAPIHandler):
+                kagglehub.model_download(VERSIONED_MODEL_HANDLE, path=TEST_FILEPATH)
+
+            # No internet should throw an error.
+            with self.assertRaises(requests.exceptions.ConnectionError):
+                kagglehub.model_download(VERSIONED_MODEL_HANDLE, path=TEST_FILEPATH, force_download=True)
+
+    def test_versioned_model_download_already_cached_with_force_download_explicit_false(self):
+        with create_test_cache() as d:
+            with create_test_http_server(KaggleAPIHandler):
+                kagglehub.model_download(VERSIONED_MODEL_HANDLE)
+
+            # Not force downloaded, cache hit.
+            model_path = kagglehub.model_download(VERSIONED_MODEL_HANDLE, force_download=False)
+
+            self.assertEqual(os.path.join(d, EXPECTED_MODEL_SUBDIR), model_path)
+
+    def test_versioned_model_download_with_path_already_cached_with_force_download_explicit_false(self):
+        with create_test_cache() as d:
+            with create_test_http_server(KaggleAPIHandler):
+                kagglehub.model_download(VERSIONED_MODEL_HANDLE, path=TEST_FILEPATH)
+
+            # Not force downloaded, cache hit.
+            model_path = kagglehub.model_download(VERSIONED_MODEL_HANDLE, path=TEST_FILEPATH, force_download=False)
+
+            self.assertEqual(os.path.join(d, EXPECTED_MODEL_SUBPATH), model_path)

--- a/tests/test_kaggle_cache_model_download.py
+++ b/tests/test_kaggle_cache_model_download.py
@@ -118,10 +118,15 @@ class TestKaggleCacheModelDownload(BaseTestCase):
         with self.assertRaises(ValueError):
             kagglehub.model_download("bad handle")
 
-    def test_versioned_model_download_force_download_raises(self):
+    def test_versioned_model_download_with_force_download(self):
         with create_test_jwt_http_server(KaggleJwtHandler):
-            with self.assertRaises(ValueError):
-                kagglehub.model_download(VERSIONED_MODEL_HANDLE, force_download=True)
+            model_path = kagglehub.model_download(VERSIONED_MODEL_HANDLE)
+            model_path_forced = kagglehub.model_download(VERSIONED_MODEL_HANDLE, force_download=True)
+
+            # Using force_download shouldn't change the expected output of model_download.
+            self.assertTrue(model_path_forced.endswith("/1"))
+            self.assertEqual(["config.json"], sorted(os.listdir(model_path_forced)))
+            self.assertEqual(model_path, model_path_forced)
 
     def test_versioned_model_download_with_force_download_explicitly_false(self):
         with create_test_jwt_http_server(KaggleJwtHandler):

--- a/tests/test_kaggle_cache_model_download.py
+++ b/tests/test_kaggle_cache_model_download.py
@@ -117,3 +117,8 @@ class TestKaggleCacheModelDownload(BaseTestCase):
     def test_versioned_model_download_bad_handle_raises(self):
         with self.assertRaises(ValueError):
             kagglehub.model_download("bad handle")
+
+    def test_versioned_model_download_force_download_raises(self):
+        with create_test_jwt_http_server(KaggleJwtHandler):
+            with self.assertRaises(ValueError):
+                kagglehub.model_download(VERSIONED_MODEL_HANDLE, force_download="hiksjdhf")

--- a/tests/test_kaggle_cache_model_download.py
+++ b/tests/test_kaggle_cache_model_download.py
@@ -121,4 +121,10 @@ class TestKaggleCacheModelDownload(BaseTestCase):
     def test_versioned_model_download_force_download_raises(self):
         with create_test_jwt_http_server(KaggleJwtHandler):
             with self.assertRaises(ValueError):
-                kagglehub.model_download(VERSIONED_MODEL_HANDLE, force_download="hiksjdhf")
+                kagglehub.model_download(VERSIONED_MODEL_HANDLE, force_download=True)
+
+    def test_versioned_model_download_with_force_download_explicitly_false(self):
+        with create_test_jwt_http_server(KaggleJwtHandler):
+            model_path = kagglehub.model_download(VERSIONED_MODEL_HANDLE, force_download=False)
+            self.assertTrue(model_path.endswith("/1"))
+            self.assertEqual(["config.json"], sorted(os.listdir(model_path)))


### PR DESCRIPTION
Previously, after a model or file was downloaded with `model_download`, there was no way to programmatically force a new download. This PR enables forced downloads.

More Details
* This feature can only be used outside of Kaggle notebooks. Kaggle notebooks rely on a different caching mechanism where force_download is not yet possible
* `force_download` defaults to False
* If a file is force downloaded, the other files in the same folder are not force downloaded

New flag usage:
```
kagglehub.model_download(model_handle, force_download=True)
kagglehub.model_download(model_handle, path=path, force_download=True)
```