### PR TITLE
Prevent same log message from being printed twice in some env.

### DIFF
--- a/src/kagglehub/auth.py
+++ b/src/kagglehub/auth.py
@@ -33,7 +33,6 @@ def _capture_logger_output():
     """
     buffer = io.StringIO()
     handler = logging.StreamHandler(buffer)
-    logger = logging.getLogger()
     logger.addHandler(handler)
     try:
         yield buffer

--- a/src/kagglehub/logging.py
+++ b/src/kagglehub/logging.py
@@ -7,6 +7,9 @@ def _configure_logger():
     library_name = __name__.split(".")[0]  # i.e. "kagglehub"
     library_logger = logging.getLogger(library_name)
     library_logger.addHandler(logging.StreamHandler())
+    # Disable propagation of the library log outputs.
+    # This prevents the same message again from being printed again if a root logger is defined.
+    library_logger.propagate = False
     library_logger.setLevel(get_log_verbosity())
 
 


### PR DESCRIPTION
For instance, the Colab environment had this double logging issue:

Before: https://screenshot.googleplex.com/6oSgAgt9A9ex25k
After: https://screenshot.googleplex.com/5fR6EKCpPhDhLn9

http://b/318761951