### PR TITLE
Release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,22 @@ The following shows how to run `hatch run lint:all` but this also works for any 
 # Use specific Python version (Must be a valid tag from: https://hub.docker.com/_/python)
 ./docker-hatch -v 3.9 run lint:all
 ```
+
+## Release
+
+### Prerequisite
+
+Create a new version: 
+
+```
+NEW_VERSION=X.Y.X
+hatch version $NEW_VERSION
+```
+
+Update and commit CHANGELOG.md with the new version `X.Y.Z`
+
+### Create a new release
+
+```
+gcloud builds submit --project=kaggle-cicd --config=tools/release/cloudbuild.yaml . --substitutions=_NEW_VERSION=$NEW_VERSION
+```

--- a/README.md
+++ b/README.md
@@ -129,22 +129,3 @@ The following shows how to run `hatch run lint:all` but this also works for any 
 # Use specific Python version (Must be a valid tag from: https://hub.docker.com/_/python)
 ./docker-hatch -v 3.9 run lint:all
 ```
-
-## Release
-
-### Prerequisite
-
-Create a new version: 
-
-```
-NEW_VERSION=X.Y.X
-hatch version $NEW_VERSION
-```
-
-Update and commit CHANGELOG.md with the new version `X.Y.Z`
-
-### Create a new release
-
-```
-gcloud builds submit --project=kaggle-cicd --config=tools/release/cloudbuild.yaml . --substitutions=_NEW_VERSION=$NEW_VERSION
-```

--- a/tools/release/cloudbuild.yaml
+++ b/tools/release/cloudbuild.yaml
@@ -1,5 +1,22 @@
 steps:
 
+# Validate substitution variables.
+- name: 'ubuntu'
+  id: validation
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    if [[ $_NEW_VERSION == "default" ]]; then
+      echo "Specify _NEW_VERSION"
+      exit 1
+    elif [[ $_NEW_VERSION =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
+      echo "_NEW_VERSION format validated."
+    else
+      echo "_NEW_VERSION=$_NEW_VERSION must follow the format '^[0-9]+.[0-9]+.[0-9]+$' (example: 1.2.3)"
+      exit 1
+    fi
+
 # Get the GitHub access token from Secret Manager.
 # The token is used to talk to GitHub API, specifically to create a release.
 - name: gcr.io/cloud-builders/gcloud
@@ -61,16 +78,6 @@ steps:
   - run
   - lint:all
 
-# Delete old releases if exist.
-- name: 'ubuntu'
-  id: clean
-  dir: $_GITHUB_REPOSITORY
-  entrypoint: 'bash'
-  args:
-  - '-c'
-  - |
-    rm -rf dist || exit 0
-
 - name: gcr.io/$PROJECT_ID/hatch:${_PYTHON_VERSION}
   id: build
   dir: $_GITHUB_REPOSITORY
@@ -115,5 +122,5 @@ steps:
 substitutions:
   _GITHUB_REPOSITORY: kagglehub
   _PYTHON_VERSION: 3.9.18
-  _NEW_VERSION: 0.0.1
+  _NEW_VERSION: default
 

--- a/tools/release/cloudbuild.yaml
+++ b/tools/release/cloudbuild.yaml
@@ -1,0 +1,139 @@
+steps:
+
+# Get the GitHub access token from Secret Manager.
+# The token is used to talk to GitHub API, specifically to create a release.
+- name: gcr.io/cloud-builders/gcloud
+  id: 'github-token'
+  entrypoint: 'bash'
+  args: 
+  - '-c'
+  - 'gcloud secrets versions access latest --secret=kaggleteam-github-access-token > /root/github_token'
+  volumes:
+  - name: 'root'
+    path: /root
+
+# Get the pypi password from Secret Manager, and create the ~/.pypirc file.
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: create-credentials-pypirc
+  entrypoint: 'bash'
+  args:
+    - '-c'
+    - |
+      token_test=$(gcloud secrets versions access latest --secret=test-pypi-token)
+      token=$(gcloud secrets versions access latest --secret=pypi-token)
+      cat >~/.pypirc <<EOL
+      [distutils]
+      index-servers =
+        pypi
+        pypitest
+      [pypi]
+      repository: https://upload.pypi.org/legacy/
+      username=__token__
+      password=${token}
+      [pypitest]
+      repository: https://test.pypi.org/legacy/
+      username=__token__
+      password=${token_test}
+      EOL
+  volumes:
+  - name: 'root'
+    path: /root
+
+# Pull the repository from GitHub.
+- name: 'gcr.io/cloud-builders/git'
+  id: clone-repo
+  args:
+  - clone
+  - https://github.com/kaggle/$_GITHUB_REPOSITORY.git
+
+# The hatch docker image is built with the tools/cicd/cloudbuild.yaml build.
+- name: gcr.io/$PROJECT_ID/hatch:${_PYTHON_VERSION}
+  id: tests
+  dir: $_GITHUB_REPOSITORY
+  args:
+  - run
+  - test
+
+- name: gcr.io/$PROJECT_ID/hatch:${_PYTHON_VERSION}
+  id: lint
+  dir: $_GITHUB_REPOSITORY
+  args:
+  - run
+  - lint:all
+
+# Create a release on GitHub.
+# The `hub` image has been built previously in the project:
+# $ git clone https://github.com/GoogleCloudPlatform/cloud-builders-community.git
+# $ cd cloud-builders-community/hub
+# $ gcloud builds submit
+- name: 'gcr.io/$PROJECT_ID/hub'
+  id: 'release'
+  dir: $_GITHUB_REPOSITORY
+  args:
+  - '-c'
+  - |
+    export GITHUB_TOKEN=$(</root/github_token)
+    hub release create -m "release v$_NEW_VERSION" "v$_NEW_VERSION"
+  env:
+  - GITHUB_USER=kaggle
+  - GITHUB_REPOSITORY=$_GITHUB_REPOSITORY
+  - HUB_PROTOCOL=https
+  volumes:
+  - name: 'root'
+    path: /root
+
+# Delete old releases if exist.
+- name: 'ubuntu'
+  id: clean
+  dir: $_GITHUB_REPOSITORY
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    rm -rf dist || exit 0
+
+- name: gcr.io/$PROJECT_ID/hatch:${_PYTHON_VERSION}
+  id: build
+  dir: $_GITHUB_REPOSITORY
+  args:
+  - build
+
+- name: gcr.io/$PROJECT_ID/hatch:${_PYTHON_VERSION}
+  id: release-pypitest
+  dir: $_GITHUB_REPOSITORY
+  entrypoint: bash
+  args:
+  - '-c'
+  - |
+    if [ "$_TO_TEST" = "false" ] ; then
+        echo "Deployment to pypitest disabled, set substitution _TO_TEST to true if you want otherwise."
+        exit 0
+    fi
+    twine upload dist/* -r pypitest
+  volumes:
+  - name: 'root'
+    path: /root
+
+- name: gcr.io/$PROJECT_ID/hatch:${_PYTHON_VERSION}
+  id: release-pypi
+  dir: $_GITHUB_REPOSITORY
+  entrypoint: bash 
+  args:
+  - '-c'
+  - |
+    if [ "$_TO_PROD" = "false" ] ; then
+        echo "Deployment to pypi disabled, set substitution _TO_PROD to true if you want otherwise."
+        exit 0
+    fi
+    twine upload dist/* -r pypi
+  volumes:
+  - name: 'root'
+    path: /root
+
+substitutions:
+  _GITHUB_REPOSITORY: kagglehub
+  _PYTHON_VERSION: 3.9.18
+  _NEW_VERSION: 0.0.1
+  _TO_TEST: "true"
+  _TO_PROD: "false"
+

--- a/tools/release/cloudbuild.yaml
+++ b/tools/release/cloudbuild.yaml
@@ -61,27 +61,6 @@ steps:
   - run
   - lint:all
 
-# Create a release on GitHub.
-# The `hub` image has been built previously in the project:
-# $ git clone https://github.com/GoogleCloudPlatform/cloud-builders-community.git
-# $ cd cloud-builders-community/hub
-# $ gcloud builds submit
-- name: 'gcr.io/$PROJECT_ID/hub'
-  id: 'release'
-  dir: $_GITHUB_REPOSITORY
-  args:
-  - '-c'
-  - |
-    export GITHUB_TOKEN=$(</root/github_token)
-    hub release create -m "release v$_NEW_VERSION" "v$_NEW_VERSION"
-  env:
-  - GITHUB_USER=kaggle
-  - GITHUB_REPOSITORY=$_GITHUB_REPOSITORY
-  - HUB_PROTOCOL=https
-  volumes:
-  - name: 'root'
-    path: /root
-
 # Delete old releases if exist.
 - name: 'ubuntu'
   id: clean
@@ -98,22 +77,29 @@ steps:
   args:
   - build
 
-- name: gcr.io/$PROJECT_ID/hatch:${_PYTHON_VERSION}
-  id: release-pypitest
+# Create a release on GitHub.
+# The `hub` image has been built previously in the project:
+# $ git clone https://github.com/GoogleCloudPlatform/cloud-builders-community.git
+# $ cd cloud-builders-community/hub
+# $ gcloud builds submit
+- name: 'gcr.io/$PROJECT_ID/hub'
+  id: 'release'
   dir: $_GITHUB_REPOSITORY
-  entrypoint: bash
+  entrypoint: 'bash'
   args:
   - '-c'
   - |
-    if [ "$_TO_TEST" = "false" ] ; then
-        echo "Deployment to pypitest disabled, set substitution _TO_TEST to true if you want otherwise."
-        exit 0
-    fi
-    twine upload dist/* -r pypitest
+    export GITHUB_TOKEN=$(</root/github_token)
+    hub release create -m "release v$_NEW_VERSION" "v$_NEW_VERSION"
+  env:
+  - GITHUB_USER=kaggle
+  - GITHUB_REPOSITORY=$_GITHUB_REPOSITORY
+  - HUB_PROTOCOL=https
   volumes:
   - name: 'root'
     path: /root
 
+# Release package to pypi.
 - name: gcr.io/$PROJECT_ID/hatch:${_PYTHON_VERSION}
   id: release-pypi
   dir: $_GITHUB_REPOSITORY
@@ -121,10 +107,6 @@ steps:
   args:
   - '-c'
   - |
-    if [ "$_TO_PROD" = "false" ] ; then
-        echo "Deployment to pypi disabled, set substitution _TO_PROD to true if you want otherwise."
-        exit 0
-    fi
     twine upload dist/* -r pypi
   volumes:
   - name: 'root'
@@ -134,6 +116,4 @@ substitutions:
   _GITHUB_REPOSITORY: kagglehub
   _PYTHON_VERSION: 3.9.18
   _NEW_VERSION: 0.0.1
-  _TO_TEST: "true"
-  _TO_PROD: "false"
 


### PR DESCRIPTION
Use a GCB build to release a new version of kagglehub both on pypi and in this repo as a GitHub release.

I ran it for `0.1.5`: 
- pypi: https://pypi.org/project/kagglehub/0.1.5/#history
- GitHub release: https://github.com/Kaggle/kagglehub/releases/tag/v0.1.5

http://b/314006079