### PR TITLE
[b/317131904] Make license_name param optional for model_upload method

### DIFF
--- a/src/kagglehub/models.py
+++ b/src/kagglehub/models.py
@@ -25,7 +25,9 @@ def model_download(handle: str, path: Optional[str] = None, *, force_download: O
     return registry.model_resolver(h, path, force_download=force_download)
 
 
-def model_upload(handle: str, local_model_dir: str, license_name: Optional[str] = None, version_notes: Optional[str] = ""):
+def model_upload(
+    handle: str, local_model_dir: str, license_name: Optional[str] = None, version_notes: Optional[str] = ""
+):
     """Upload model files.
 
     Args:

--- a/src/kagglehub/models.py
+++ b/src/kagglehub/models.py
@@ -25,7 +25,7 @@ def model_download(handle: str, path: Optional[str] = None, *, force_download: O
     return registry.model_resolver(h, path, force_download=force_download)
 
 
-def model_upload(handle: str, local_model_dir: str, license_name: str, version_notes: Optional[str] = ""):
+def model_upload(handle: str, local_model_dir: str, license_name: Optional[str] = None, version_notes: Optional[str] = ""):
     """Upload model files.
 
     Args:
@@ -48,4 +48,4 @@ def model_upload(handle: str, local_model_dir: str, license_name: str, version_n
     tokens = upload_files(local_model_dir, "model")
 
     # Create a model instance if it doesn't exist, and create a new instance version if an instance exists
-    create_model_instance_or_version(h, license_name, tokens, version_notes)
+    create_model_instance_or_version(h, tokens, license_name, version_notes)

--- a/src/kagglehub/models_helpers.py
+++ b/src/kagglehub/models_helpers.py
@@ -20,9 +20,11 @@ def _create_model_instance(model_handle: ModelHandle, files: List[str], license_
     data = {
         "instanceSlug": model_handle.variation,
         "framework": model_handle.framework,
-        "licenseName": license_name,
         "files": [{"token": file_token} for file_token in files],
     }
+    if license_name is not None:
+        data["licenseName"] = license_name
+
     api_client = KaggleApiV1Client()
     api_client.post(f"/models/{model_handle.owner}/{model_handle.model}/create/instance", data)
     logger.info(f"Model Instance for '{model_handle}' Created.")

--- a/src/kagglehub/models_helpers.py
+++ b/src/kagglehub/models_helpers.py
@@ -16,7 +16,7 @@ def _create_model(owner_slug: str, model_slug: str):
     logger.info(f"Model '{model_slug}' Created.")
 
 
-def _create_model_instance(model_handle: ModelHandle, license_name: str, files: List[str]):
+def _create_model_instance(model_handle: ModelHandle, files: List[str], license_name: Optional[str] = None):
     data = {
         "instanceSlug": model_handle.variation,
         "framework": model_handle.framework,
@@ -39,7 +39,7 @@ def _create_model_instance_version(model_handle: ModelHandle, files: List[str], 
 
 
 def create_model_instance_or_version(
-    model_handle: ModelHandle, license_name: str, files: List[str], version_notes: Optional[str] = None
+    model_handle: ModelHandle, files: List[str], license_name: Optional[str] = None, version_notes: Optional[str] = None
 ):
     try:
         api_client = KaggleApiV1Client()
@@ -48,7 +48,7 @@ def create_model_instance_or_version(
         _create_model_instance_version(model_handle, files, version_notes)
     except KaggleApiHTTPError as e:
         if e.response is not None and e.response.status_code == HTTPStatus.NOT_FOUND:
-            _create_model_instance(model_handle, license_name, files)
+            _create_model_instance(model_handle, files, license_name)
         else:
             raise (e)
 

--- a/tests/test_model_upload.py
+++ b/tests/test_model_upload.py
@@ -58,14 +58,14 @@ class KaggleAPIHandler(BaseHTTPRequestHandler):
             self.send_header("Content-type", "application/json")
             self.end_headers()
             self.wfile.write(json.dumps({"status": "success", "message": "Model created successfully"}).encode("utf-8"))
-        elif instance_or_version in ("instance", "version"):            
+        elif instance_or_version in ("instance", "version"):
             self.send_response(200)
             self.send_header("Content-type", "application/json")
             self.end_headers()
-            if data.get('licenseName') not in ALLOWED_LICENSE_VALUES:
+            if data.get("licenseName") not in ALLOWED_LICENSE_VALUES:
                 error_message = json.dumps({"error": f"bad: {self.path}"})
                 self.wfile.write(bytes(error_message, "utf-8"))
-            else: 
+            else:
                 response = {"status": "success", "message": "Model Instance/Version created successfully"}
                 self.wfile.write(json.dumps(response).encode("utf-8"))
         elif self.path == "/api/v1/blobs/upload":
@@ -185,7 +185,7 @@ class TestModelUpload(BaseTestCase):
                     self.assertEqual(len(KaggleAPIHandler.UPLOAD_BLOB_FILE_NAMES), 1)
                     self.assertIn(TEMP_TEST_FILE, KaggleAPIHandler.UPLOAD_BLOB_FILE_NAMES)
 
-    def test_model_upload_with_None_license(self):
+    def test_model_upload_with_none_license(self):
         with create_test_http_server(KaggleAPIHandler):
             with create_test_http_server(GcsAPIHandler, "http://localhost:7778"):
                 with TemporaryDirectory() as temp_dir:

--- a/tests/test_model_upload.py
+++ b/tests/test_model_upload.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import ClassVar, List
 
+from kagglehub.exceptions import BackendError
 from kagglehub.gcs_upload import MAX_FILES_TO_UPLOAD, TEMP_ARCHIVE_FILE
 from kagglehub.models import model_upload
 from tests.fixtures import BaseTestCase
@@ -16,6 +17,8 @@ GET_MODEL = "/models/metaresearch/llama-2/get"
 CREATE_MODEL = "/models/create/new"
 MODEL_HANDLE = "metaresearch/llama-2/pyTorch/1"
 TEMP_TEST_FILE = "temp_test_file"
+APACHE_LICENSE = "Apache 2.0"
+ALLOWED_LICENSE_VALUES = (APACHE_LICENSE, None)
 
 
 class KaggleAPIHandler(BaseHTTPRequestHandler):
@@ -55,12 +58,16 @@ class KaggleAPIHandler(BaseHTTPRequestHandler):
             self.send_header("Content-type", "application/json")
             self.end_headers()
             self.wfile.write(json.dumps({"status": "success", "message": "Model created successfully"}).encode("utf-8"))
-        elif instance_or_version in ("instance", "version"):
+        elif instance_or_version in ("instance", "version"):            
             self.send_response(200)
             self.send_header("Content-type", "application/json")
             self.end_headers()
-            response = {"status": "success", "message": "Model Instance/Version created successfully"}
-            self.wfile.write(json.dumps(response).encode("utf-8"))
+            if data.get('licenseName') not in ALLOWED_LICENSE_VALUES:
+                error_message = json.dumps({"error": f"bad: {self.path}"})
+                self.wfile.write(bytes(error_message, "utf-8"))
+            else: 
+                response = {"status": "success", "message": "Model Instance/Version created successfully"}
+                self.wfile.write(json.dumps(response).encode("utf-8"))
         elif self.path == "/api/v1/blobs/upload":
             KaggleAPIHandler.UPLOAD_BLOB_FILE_NAMES.append(name)
             self.send_response(200)
@@ -120,7 +127,7 @@ class TestModelUpload(BaseTestCase):
                 with TemporaryDirectory() as temp_dir:
                     test_filepath = Path(temp_dir) / TEMP_TEST_FILE
                     test_filepath.touch()  # Create a temporary file in the temporary directory
-                    model_upload("invalid/invalid/invalid", temp_dir, "Apache 2.0", "model_type")
+                    model_upload("invalid/invalid/invalid", temp_dir, APACHE_LICENSE, "model_type")
                     self.assertEqual(len(KaggleAPIHandler.UPLOAD_BLOB_FILE_NAMES), 1)
                     self.assertIn(TEMP_TEST_FILE, KaggleAPIHandler.UPLOAD_BLOB_FILE_NAMES)
 
@@ -131,7 +138,7 @@ class TestModelUpload(BaseTestCase):
                 with TemporaryDirectory() as temp_dir:
                     test_filepath = Path(temp_dir) / TEMP_TEST_FILE
                     test_filepath.touch()  # Create a temporary file in the temporary directory
-                    model_upload("metaresearch/new-model/pyTorch/new-variation", temp_dir, "Apache 2.0", "model_type")
+                    model_upload("metaresearch/new-model/pyTorch/new-variation", temp_dir, APACHE_LICENSE, "model_type")
                     self.assertEqual(len(KaggleAPIHandler.UPLOAD_BLOB_FILE_NAMES), 1)
                     self.assertIn(TEMP_TEST_FILE, KaggleAPIHandler.UPLOAD_BLOB_FILE_NAMES)
 
@@ -143,7 +150,7 @@ class TestModelUpload(BaseTestCase):
                 with TemporaryDirectory() as temp_dir:
                     test_filepath = Path(temp_dir) / TEMP_TEST_FILE
                     test_filepath.touch()  # Create a temporary file in the temporary directory
-                    model_upload("metaresearch/llama-2/pyTorch/7b", temp_dir, "Apache 2.0", "model_type")
+                    model_upload("metaresearch/llama-2/pyTorch/7b", temp_dir, APACHE_LICENSE, "model_type")
                     self.assertEqual(len(KaggleAPIHandler.UPLOAD_BLOB_FILE_NAMES), 1)
                     self.assertIn(TEMP_TEST_FILE, KaggleAPIHandler.UPLOAD_BLOB_FILE_NAMES)
 
@@ -156,7 +163,7 @@ class TestModelUpload(BaseTestCase):
                         test_filepath = Path(temp_dir) / f"temp_test_file_{i}"
                         test_filepath.touch()
 
-                    model_upload("metaresearch/new-model/pyTorch/new-variation", temp_dir, "Apache 2.0", "model_type")
+                    model_upload("metaresearch/new-model/pyTorch/new-variation", temp_dir, APACHE_LICENSE, "model_type")
                     self.assertEqual(len(KaggleAPIHandler.UPLOAD_BLOB_FILE_NAMES), 1)
                     self.assertIn(TEMP_ARCHIVE_FILE, KaggleAPIHandler.UPLOAD_BLOB_FILE_NAMES)
 
@@ -171,9 +178,38 @@ class TestModelUpload(BaseTestCase):
                     with open(test_filepath, "wb") as f:
                         f.write(os.urandom(1000))
 
-                    model_upload("metaresearch/new-model/pyTorch/new-variation", temp_dir, "Apache 2.0", "model_type")
+                    model_upload("metaresearch/new-model/pyTorch/new-variation", temp_dir, APACHE_LICENSE, "model_type")
 
                     # Check that GcsAPIHandler received two PUT requests
                     self.assertEqual(GcsAPIHandler.put_requests_count, 2)
                     self.assertEqual(len(KaggleAPIHandler.UPLOAD_BLOB_FILE_NAMES), 1)
                     self.assertIn(TEMP_TEST_FILE, KaggleAPIHandler.UPLOAD_BLOB_FILE_NAMES)
+
+    def test_model_upload_with_None_license(self):
+        with create_test_http_server(KaggleAPIHandler):
+            with create_test_http_server(GcsAPIHandler, "http://localhost:7778"):
+                with TemporaryDirectory() as temp_dir:
+                    test_filepath = Path(temp_dir) / TEMP_TEST_FILE
+                    test_filepath.touch()  # Create a temporary file in the temporary directory
+                    model_upload("metaresearch/new-model/pyTorch/new-variation", temp_dir, None, "model_type")
+                    self.assertEqual(len(KaggleAPIHandler.UPLOAD_BLOB_FILE_NAMES), 1)
+                    self.assertIn(TEMP_TEST_FILE, KaggleAPIHandler.UPLOAD_BLOB_FILE_NAMES)
+
+    def test_model_upload_without_license(self):
+        with create_test_http_server(KaggleAPIHandler):
+            with create_test_http_server(GcsAPIHandler, "http://localhost:7778"):
+                with TemporaryDirectory() as temp_dir:
+                    test_filepath = Path(temp_dir) / TEMP_TEST_FILE
+                    test_filepath.touch()  # Create a temporary file in the temporary directory
+                    model_upload("metaresearch/new-model/pyTorch/new-variation", temp_dir, version_notes="model_type")
+                    self.assertEqual(len(KaggleAPIHandler.UPLOAD_BLOB_FILE_NAMES), 1)
+                    self.assertIn(TEMP_TEST_FILE, KaggleAPIHandler.UPLOAD_BLOB_FILE_NAMES)
+
+    def test_model_upload_with_invalid_license_fails(self):
+        with create_test_http_server(KaggleAPIHandler):
+            with create_test_http_server(GcsAPIHandler, "http://localhost:7778"):
+                with TemporaryDirectory() as temp_dir:
+                    test_filepath = Path(temp_dir) / TEMP_TEST_FILE
+                    test_filepath.touch()  # Create a temporary file in the temporary directory
+                    with self.assertRaises(BackendError):
+                        model_upload("metaresearch/new-model/pyTorch/new-variation", temp_dir, "Invalid License")


### PR DESCRIPTION
Related to: https://github.com/Kaggle/kaggleazure/pull/27324, and https://github.com/Kaggle/kaggleazure/pull/27323

Enabling this will allow other libraries (e.g. Keras) to publish private models to Model Hub (e.g. during development). Users can then set a license in the UI before making those public.

**Testing**
* Added unit tests
* Tested e2e (requires https://github.com/Kaggle/kaggleazure/pull/27462 in order for e2e to work)