### PR TITLE
Add log before extracting model file.

### DIFF
--- a/src/kagglehub/http_resolver.py
+++ b/src/kagglehub/http_resolver.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import tarfile
 from typing import Optional
@@ -14,6 +15,8 @@ from kagglehub.handle import ModelHandle
 from kagglehub.resolver import Resolver
 
 MODEL_INSTANCE_VERSION_FIELD = "versionNumber"
+
+logger = logging.getLogger(__name__)
 
 
 class ModelHttpResolver(Resolver[ModelHandle]):
@@ -57,6 +60,7 @@ class ModelHttpResolver(Resolver[ModelHandle]):
                 raise ValueError(msg)
 
             # Extract all files to this directory.
+            logger.info("Extracting model files...")
             with tarfile.open(archive_path) as f:
                 # Model archives are created by Kaggle via the Databundle Worker.
                 f.extractall(out_path)


### PR DESCRIPTION
Extracting (unzipping) can take several seconds for large models. Adding an extra log statement to clarify that we are not simply hanging after the download completes.

```
$ hatch run python -c "import kagglehub; print(kagglehub.model_download('keras/bert/keras/bert_tiny_en_uncased'))"

Downloading from https://www.kaggle.com/api/v1/models/keras/bert/keras/bert_tiny_en_uncased/2/download...
100%|███████████████████████████████| 15.6M/15.6M [00:00<00:00, 139MB/s]
Extracting model files...
```