### PR TITLE
Fix message when detecting newer version

### DIFF
--- a/src/kagglehub/clients.py
+++ b/src/kagglehub/clients.py
@@ -91,8 +91,8 @@ class KaggleApiV1Client:
             latest_version = parse(latest_version_str)
             if latest_version > current_version:
                 logger.info(
-                    "Warning: Looks like you\'re using an outdated KaggleHub "
-                    "Version, please consider updating (latest version: {latest_version})"
+                    "Warning: Looks like you\'re using an outdated `kagglehub` "
+                    f"version, please consider updating (latest version: {latest_version})"
                 )
 
     def get(self, path: str, resource_handle: Optional[ResourceHandle] = None) -> dict:


### PR DESCRIPTION
Before (`latest_version` was not interpolated properly, fixed casing too):

> Warning: Looks like you're using an outdated KaggleHub Version, please consider updating (latest version: {latest_version})

After:

> Warning: Looks like you're using an outdated KaggleHub version, please consider updating (latest version: 0.1.8)

http://b/321791392