### PR TITLE
[b/329212240] Update kagglehub to reference short model URLs only

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Note for Windows users: The default directory is `%HOMEPATH%/kaggle.json`.
 
 ### Download Model
 
-The following examples download the `answer-equivalence-bem` variation of this Kaggle model: https://www.kaggle.com/models/google/bert/frameworks/tensorFlow2/variations/answer-equivalence-bem
+The following examples download the `answer-equivalence-bem` variation of this Kaggle model: https://www.kaggle.com/models/google/bert/tensorFlow2/answer-equivalence-bem
 
 ```python
 import kagglehub
@@ -74,7 +74,7 @@ Uploads a new variation (or a new variation's version if it already exists).
 import kagglehub
 
 # For example, to upload a new variation to this model:
-# - https://www.kaggle.com/models/google/bert/frameworks/tensorFlow2/variations/answer-equivalence-bem
+# - https://www.kaggle.com/models/google/bert/tensorFlow2/answer-equivalence-bem
 # 
 # You would use the following handle: `google/bert/tensorFlow2/answer-equivalence-bem`
 handle = '<KAGGLE_USERNAME>/<MODEL>/<FRAMEWORK>/<VARIATION>'

--- a/src/kagglehub/handle.py
+++ b/src/kagglehub/handle.py
@@ -38,9 +38,9 @@ class ModelHandle(ResourceHandle):
 
     def to_url(self) -> str:
         if self.is_versioned():
-            return f"https://www.kaggle.com/models/{self.owner}/{self.model}/frameworks/{self.framework}/variations/{self.variation}/versions/{self.version}"
+            return f"https://www.kaggle.com/models/{self.owner}/{self.model}/{self.framework}/{self.variation}/{self.version}"
         else:
-            return f"https://www.kaggle.com/models/{self.owner}/{self.model}/frameworks/{self.framework}/variations/{self.variation}"
+            return f"https://www.kaggle.com/models/{self.owner}/{self.model}/{self.framework}/{self.variation}"
 
 
 @dataclass


### PR DESCRIPTION
Kaggle has been updated to use short URLs (though is backwards compatible with long URLs). This updates kagglehub to use short URLs.

Example:
* Short: https://www.kaggle.com/models/google/movenet/tfLite/singlepose-thunder
* Long: https://www.kaggle.com/models/google/movenet/frameworks/tfLite/variations/singlepose-thunder

**Testing**
Tested locally