### PR TITLE
Added functionality to allow model_upload using a single file rather than just a directory.

### DIFF
--- a/integration_tests/test_model_upload.py
+++ b/integration_tests/test_model_upload.py
@@ -130,5 +130,12 @@ class TestModelUpload(unittest.TestCase):
         # Call the model upload function with the base directory
         model_upload(self.handle, self.temp_dir, LICENSE_NAME)
 
+    def test_single_file_upload(self) -> None:
+        single_file_path = Path(self.temp_dir) / "dummy_file.txt"
+        with open(single_file_path, "wb") as f:
+            f.write(os.urandom(100))
+
+        model_upload(self.handle, str(single_file_path), LICENSE_NAME)
+
     def tearDown(self) -> None:
         models_helpers.delete_model(self.owner_slug, self.model_slug)


### PR DESCRIPTION
This is done in response to some users requesting this feature. see https://docs.google.com/document/d/1kXEqOWB2AtraW-D2vSHGq9XcdsuoGUIsGrOggcWXFzQ/edit?resourcekey=0-IUcAz4KC8b1kYlpeTxMisw&tab=t.0#heading=h.epw63mvrysfp



https://b.corp.google.com/issues/331603564