### PR TITLE
Add missing 'packaging' dependencies.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ keywords = ["Kaggle", "API"]
 requires-python = ">=3.7"
 dependencies = [
   "requests", 
-  "tqdm"
+  "tqdm",
+  "packaging"
 ]
 
 [project.urls]


### PR DESCRIPTION
We are using it here: https://github.com/Kaggle/kagglehub/blob/3b0006cbbcdf2b928f0d743a9d56b571fe36ab55/src/kagglehub/clients.py#L9

In a clean debian distribution, it is not included which is how I caught this gap.