### PR TITLE
Update docker-hatch for kaggle credentials

### DIFF
--- a/docker-hatch
+++ b/docker-hatch
@@ -63,4 +63,4 @@ docker build -f Dockerfile \
     .
 
 set -x
-docker run --rm -v $PWD:/working -w /working ${DOCKER_IMAGE} "$@"
+docker run --rm -v $PWD:/working -v ~/.kaggle:/root/.kaggle -w /working ${DOCKER_IMAGE} "$@"


### PR DESCRIPTION
Updates the docker-hatch to use kaggle credentials with `~/.kaggle`