### PR TITLE
Add integration test for downloading public model unauthenticated

### DIFF
--- a/integration_tests/test_model_download.py
+++ b/integration_tests/test_model_download.py
@@ -6,7 +6,7 @@ from requests import HTTPError
 
 from kagglehub import model_download
 
-from .utils import create_test_cache
+from .utils import create_test_cache, unauthenticated
 
 HANDLE = "keras/bert/keras/bert_tiny_en_uncased/2"
 
@@ -72,6 +72,21 @@ class TestModelDownload(unittest.TestCase):
                 "./tokenizer.json",
             ]
             self.assert_files(actual_path, expected_files)
+
+    def test_public_model_as_unauthenticated_succeeds(self) -> None:
+        with create_test_cache():
+            with unauthenticated():
+                unversioned_handle = "keras/bert/keras/bert_tiny_en_uncased"
+                actual_path = model_download(unversioned_handle)
+
+                expected_files = [
+                    "assets/tokenizer/vocabulary.txt",
+                    "./config.json",
+                    "./metadata.json",
+                    "./model.weights.h5",
+                    "./tokenizer.json",
+                ]
+                self.assert_files(actual_path, expected_files)
 
     def test_download_private_model_succeeds(self) -> None:
         with create_test_cache():

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -4,7 +4,7 @@ from tempfile import TemporaryDirectory
 from typing import Generator
 from unittest import mock
 
-from kagglehub.config import CACHE_FOLDER_ENV_VAR_NAME
+from kagglehub.config import CACHE_FOLDER_ENV_VAR_NAME, USERNAME_ENV_VAR_NAME, KEY_ENV_VAR_NAME
 
 
 @contextmanager
@@ -12,3 +12,11 @@ def create_test_cache() -> Generator[str, None, None]:
     with TemporaryDirectory() as d:
         with mock.patch.dict(os.environ, {CACHE_FOLDER_ENV_VAR_NAME: d}):
             yield d
+
+@contextmanager
+def unauthenticated() -> Generator[None, None, None]:
+    with mock.patch.dict(os.environ, {
+        USERNAME_ENV_VAR_NAME: "",
+        KEY_ENV_VAR_NAME: "",
+    }):
+        yield

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -4,7 +4,7 @@ from tempfile import TemporaryDirectory
 from typing import Generator
 from unittest import mock
 
-from kagglehub.config import CACHE_FOLDER_ENV_VAR_NAME, USERNAME_ENV_VAR_NAME, KEY_ENV_VAR_NAME
+from kagglehub.config import CACHE_FOLDER_ENV_VAR_NAME, KEY_ENV_VAR_NAME, USERNAME_ENV_VAR_NAME
 
 
 @contextmanager
@@ -13,10 +13,14 @@ def create_test_cache() -> Generator[str, None, None]:
         with mock.patch.dict(os.environ, {CACHE_FOLDER_ENV_VAR_NAME: d}):
             yield d
 
+
 @contextmanager
 def unauthenticated() -> Generator[None, None, None]:
-    with mock.patch.dict(os.environ, {
-        USERNAME_ENV_VAR_NAME: "",
-        KEY_ENV_VAR_NAME: "",
-    }):
+    with mock.patch.dict(
+        os.environ,
+        {
+            USERNAME_ENV_VAR_NAME: "",
+            KEY_ENV_VAR_NAME: "",
+        },
+    ):
         yield


### PR DESCRIPTION
We started using the `ListModelInstanceVersionFiles` in #122 (not yet released but merged). However, I noticed this doesn't work for unauthenticated users.

I added an integration test to ensure we don't regress on this once the backend is fixed.

http://b/341160276