### PR TITLE
Do not set environment variable globally in unittest to avoid side effects

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,3 @@ os.environ["KAGGLE_CONFIG_DIR"] = "/some-missing-directory"
 
 # All APIs call in tests should go to a local test server.
 os.environ["KAGGLE_API_ENDPOINT"] = "http://localhost:7777"
-
-# All JWT handlers calls in tests should go to a local test server.
-os.environ["KAGGLE_DATA_PROXY_URL"] = "http://localhost:7778"

--- a/tests/server_stubs/colab_stub.py
+++ b/tests/server_stubs/colab_stub.py
@@ -12,7 +12,6 @@ from kagglehub.clients import (
     ColabClient,
 )
 from kagglehub.colab_cache_resolver import COLAB_CACHE_MOUNT_FOLDER_ENV_VAR_NAME
-from kagglehub.config import TBE_RUNTIME_ADDR_ENV_VAR_NAME
 
 app = Flask(__name__)
 
@@ -71,7 +70,6 @@ def create_env() -> Generator[Any, Any, Any]:
         with mock.patch.dict(
             os.environ,
             {
-                TBE_RUNTIME_ADDR_ENV_VAR_NAME: "localhost:7779",
                 COLAB_CACHE_MOUNT_FOLDER_ENV_VAR_NAME: cache_mount_folder,
             },
         ):

--- a/tests/server_stubs/serv.py
+++ b/tests/server_stubs/serv.py
@@ -27,7 +27,7 @@ def start_server(
     app: Flask,
     endpoint_env_var_name: str = "KAGGLE_API_ENDPOINT",
     endpoint_env_var_value: str = "http://localhost:7777",
-) -> None:
+) -> ServerThread:
     env_var_patch = mock.patch.dict(os.environ, {endpoint_env_var_name: endpoint_env_var_value})
     env_var_patch.start()
 

--- a/tests/server_stubs/serv.py
+++ b/tests/server_stubs/serv.py
@@ -1,4 +1,7 @@
+import os
 import threading
+from typing import Callable
+from unittest import mock
 
 from flask import Flask
 from werkzeug.serving import make_server
@@ -7,27 +10,33 @@ from ..utils import resolve_endpoint
 
 
 class ServerThread(threading.Thread):
-    def __init__(self, app: Flask, host: str, port: int):
+    def __init__(self, app: Flask, host: str, port: int, shutdown_callback: Callable):
         threading.Thread.__init__(self)
         self.server = make_server(host, port, app)
+        self.shutdown_callback = shutdown_callback
 
     def run(self) -> None:
         self.server.serve_forever()
 
     def shutdown(self) -> None:
         self.server.shutdown()
+        self.shutdown_callback()
 
 
-server: ServerThread
+def start_server(
+    app: Flask,
+    endpoint_env_var_name: str = "KAGGLE_API_ENDPOINT",
+    endpoint_env_var_value: str = "http://localhost:7777",
+) -> None:
+    env_var_patch = mock.patch.dict(os.environ, {endpoint_env_var_name: endpoint_env_var_value})
+    env_var_patch.start()
 
+    address, port = resolve_endpoint(endpoint_env_var_name)
 
-def start_server(app: Flask, var_name: str = "KAGGLE_API_ENDPOINT") -> None:
-    global server  # noqa: PLW0603
-    address, port = resolve_endpoint(var_name)
-    server = ServerThread(app, address, port)
+    def shutdown_callback() -> None:
+        env_var_patch.stop()
+
+    server = ServerThread(app, address, port, shutdown_callback=shutdown_callback)
     server.start()
 
-
-def stop_server() -> None:
-    global server  # noqa: PLW0602
-    server.shutdown()
+    return server

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -16,11 +16,11 @@ from .server_stubs import serv
 class TestAuth(BaseTestCase):
     @classmethod
     def setUpClass(cls):
-        serv.start_server(stub.app)
+        cls.server = serv.start_server(stub.app)
 
     @classmethod
     def tearDownClass(cls):
-        serv.stop_server()
+        cls.server.shutdown()
 
     def test_login_updates_global_credentials(self) -> None:
         with mock.patch("builtins.input") as mock_input:

--- a/tests/test_colab_cache_model_download.py
+++ b/tests/test_colab_cache_model_download.py
@@ -20,14 +20,13 @@ UNAVAILABLE_MODEL_HANDLE = "unavailable/model/handle/colab/1"
 class TestColabCacheModelDownload(BaseTestCase):
     @classmethod
     def setUpClass(cls):
-        # TODO: b/337257114 - the colab environment variable has flaky behavior if set in `tests/__init__.py`.
-        os.environ[TBE_RUNTIME_ADDR_ENV_VAR_NAME] = "http://localhost:7779"
-        serv.start_server(stub.app, TBE_RUNTIME_ADDR_ENV_VAR_NAME)
+        # Important, to match Colab TBE_RUNTIME_ADDR value in production, we don't prepend `http://`.
+        # The `http://` is prepended inside the ColabClient class.
+        cls.server = serv.start_server(stub.app, TBE_RUNTIME_ADDR_ENV_VAR_NAME, "localhost:7779")
 
     @classmethod
     def tearDownClass(cls):
-        serv.stop_server()
-        del os.environ[TBE_RUNTIME_ADDR_ENV_VAR_NAME]
+        cls.server.shutdown()
 
     def test_unversioned_model_download(self) -> None:
         with stub.create_env():

--- a/tests/test_http_model_download.py
+++ b/tests/test_http_model_download.py
@@ -33,11 +33,11 @@ EXPECTED_MODEL_SUBPATH = os.path.join(
 class TestHttpModelDownload(BaseTestCase):
     @classmethod
     def setUpClass(cls):
-        serv.start_server(stub.app)
+        cls.server = serv.start_server(stub.app)
 
     @classmethod
     def tearDownClass(cls):
-        serv.stop_server()
+        cls.server.shutdown()
 
     def _download_model_and_assert_downloaded(
         self,
@@ -183,9 +183,9 @@ class TestHttpModelDownload(BaseTestCase):
 class TestHttpNoInternet(BaseTestCase):
     def test_versioned_model_download_already_cached_with_force_download(self) -> None:
         with create_test_cache():
-            serv.start_server(stub.app)
+            server = serv.start_server(stub.app)
             kagglehub.model_download(VERSIONED_MODEL_HANDLE)
-            serv.stop_server()
+            server.shutdown()
 
             # No internet should throw an error.
             with self.assertRaises(requests.exceptions.ConnectionError):
@@ -193,9 +193,9 @@ class TestHttpNoInternet(BaseTestCase):
 
     def test_versioned_model_download_with_path_already_cached_with_force_download(self) -> None:
         with create_test_cache():
-            serv.start_server(stub.app)
+            server = serv.start_server(stub.app)
             kagglehub.model_download(VERSIONED_MODEL_HANDLE, path=TEST_FILEPATH)
-            serv.stop_server()
+            server.shutdown()
 
             # No internet should throw an error.
             with self.assertRaises(requests.exceptions.ConnectionError):

--- a/tests/test_kaggle_api_client.py
+++ b/tests/test_kaggle_api_client.py
@@ -12,11 +12,11 @@ from .server_stubs import serv
 class TestKaggleApiV1Client(BaseTestCase):
     @classmethod
     def setUpClass(cls):
-        serv.start_server(stub.app)
+        cls.server = serv.start_server(stub.app)
 
     @classmethod
     def tearDownClass(cls):
-        serv.stop_server()
+        cls.server.shutdown()
 
     def test_download_with_integrity_check(self) -> None:
         with TemporaryDirectory() as d:

--- a/tests/test_kaggle_cache_model_download.py
+++ b/tests/test_kaggle_cache_model_download.py
@@ -77,11 +77,11 @@ class KaggleJwtHandler(BaseHTTPRequestHandler):
 class TestKaggleCacheModelDownload(BaseTestCase):
     @classmethod
     def setUpClass(cls):
-        serv.start_server(stub.app, KAGGLE_DATA_PROXY_URL_ENV_VAR_NAME)
+        cls.server = serv.start_server(stub.app, KAGGLE_DATA_PROXY_URL_ENV_VAR_NAME, "http://localhost:7778")
 
     @classmethod
     def tearDownClass(cls):
-        serv.stop_server()
+        cls.server.shutdown()
 
     def test_unversioned_model_download(self) -> None:
         with stub.create_env():

--- a/tests/test_kaggle_cache_model_download.py
+++ b/tests/test_kaggle_cache_model_download.py
@@ -1,7 +1,4 @@
-import json
 import os
-from http.server import BaseHTTPRequestHandler
-from pathlib import Path
 from unittest import mock
 
 import requests
@@ -9,7 +6,6 @@ import requests
 import kagglehub
 from kagglehub.config import DISABLE_KAGGLE_CACHE_ENV_VAR_NAME
 from kagglehub.env import KAGGLE_DATA_PROXY_URL_ENV_VAR_NAME
-from kagglehub.kaggle_cache_resolver import ATTACH_DATASOURCE_REQUEST_NAME, KAGGLE_CACHE_MOUNT_FOLDER_ENV_VAR_NAME
 from tests.fixtures import BaseTestCase
 
 from .server_stubs import jwt_stub as stub
@@ -20,57 +16,6 @@ VERSIONED_MODEL_HANDLE = "metaresearch/llama-2/pyTorch/13b/1"
 LATEST_MODEL_VERSION = 2
 UNVERSIONED_MODEL_HANDLE = "metaresearch/llama-2/pyTorch/13b"
 TEST_FILEPATH = "config.json"
-
-
-class KaggleJwtHandler(BaseHTTPRequestHandler):
-    def do_HEAD(self) -> None:  # noqa: N802
-        self.send_response(200)
-
-    def do_POST(self) -> None:  # noqa: N802
-        if self.path.endswith(ATTACH_DATASOURCE_REQUEST_NAME):
-            content_length = int(self.headers["Content-Length"])
-            request = json.loads(self.rfile.read(content_length))
-            model_ref = request["modelRef"]
-            version_number = LATEST_MODEL_VERSION
-            if "VersionNumber" in model_ref:
-                version_number = model_ref["VersionNumber"]
-
-            mount_slug = (
-                f"{model_ref['ModelSlug']}/{model_ref['Framework']}/{model_ref['InstanceSlug']}/{version_number}"
-            )
-
-            self.send_response(200)
-            self.send_header("Content-type", "application/json")
-            self.end_headers()
-
-            # Load the files
-            cache_mount_folder = os.getenv(KAGGLE_CACHE_MOUNT_FOLDER_ENV_VAR_NAME)
-            base_path = f"{cache_mount_folder}/{mount_slug}"
-            os.makedirs(base_path, exist_ok=True)
-
-            Path(f"{base_path}/config.json").touch()
-
-            if version_number == LATEST_MODEL_VERSION:
-                # The latest version has an extra file.
-                Path(f"{base_path}/model.keras").touch()
-
-            # Return the response
-            self.wfile.write(
-                bytes(
-                    json.dumps(
-                        {
-                            "wasSuccessful": True,
-                            "result": {
-                                "mountSlug": mount_slug,
-                            },
-                        }
-                    ),
-                    "utf-8",
-                )
-            )
-        else:
-            self.send_response(404)
-            self.wfile.write(bytes(f"Unhandled path: {self.path}", "utf-8"))
 
 
 # Test cases for the ModelKaggleCacheResolver.

--- a/tests/test_model_upload.py
+++ b/tests/test_model_upload.py
@@ -20,11 +20,11 @@ class TestModelUpload(BaseTestCase):
 
     @classmethod
     def setUpClass(cls):
-        serv.start_server(stub.app)
+        cls.server = serv.start_server(stub.app)
 
     @classmethod
     def tearDownClass(cls):
-        serv.stop_server()
+        cls.server.shutdown()
 
     def test_model_upload_with_invalid_handle(self) -> None:
         with self.assertRaises(ValueError):


### PR DESCRIPTION
- `start_server` is responsible to set the proper env variable.
- use `mock.patch.dict(os.environ, ...)` instead of overwriting os.environ directly to avoid side-effects.
- move away from using a global var for the server to enable using two servers if needed in the future (API + Colab).


http://b/337257114