### PR TITLE
kagglehub exception is suppressing internal exception

### DIFF
--- a/src/kagglehub/exceptions.py
+++ b/src/kagglehub/exceptions.py
@@ -107,6 +107,7 @@ def process_post_response(response: Dict[str, Any]) -> None:
     """
     Postprocesses the API response to check for errors.
     """
+    print(response)
     if not (200 <= response.get("code", 200) < 300):  # noqa: PLR2004
         error_message = response.get("message", "No error message provided")
         raise BackendError(error_message)

--- a/src/kagglehub/exceptions.py
+++ b/src/kagglehub/exceptions.py
@@ -107,7 +107,7 @@ def process_post_response(response: Dict[str, Any]) -> None:
     """
     Postprocesses the API response to check for errors.
     """
-    print(response)
+    print("dd", response)
     if not (200 <= response.get("code", 200) < 300):  # noqa: PLR2004
         error_message = response.get("message", "No error message provided")
         raise BackendError(error_message)

--- a/src/kagglehub/models_helpers.py
+++ b/src/kagglehub/models_helpers.py
@@ -60,7 +60,7 @@ def create_model_instance_or_version(
     try:
         _create_model_instance(model_handle, files, license_name)
     except BackendError as e:
-        if e.error_code == HTTPStatus.CONFLICT:
+        if e.error_code == HTTPStatus.CONFLICT or "already used by another model instance" in str(e):
             # Instance already exist, creating a new version instead.
             _create_model_instance_version(model_handle, files, version_notes)
         else:

--- a/src/kagglehub/models_helpers.py
+++ b/src/kagglehub/models_helpers.py
@@ -60,7 +60,7 @@ def create_model_instance_or_version(
     try:
         _create_model_instance(model_handle, files, license_name)
     except BackendError as e:
-        # print("hey", e)
+        print("hey", e)
         if e.error_code == HTTPStatus.CONFLICT or "already used by another model instance" in str(e):
             # Instance already exist, creating a new version instead.
             _create_model_instance_version(model_handle, files, version_notes)

--- a/src/kagglehub/models_helpers.py
+++ b/src/kagglehub/models_helpers.py
@@ -60,7 +60,7 @@ def create_model_instance_or_version(
     try:
         _create_model_instance(model_handle, files, license_name)
     except BackendError as e:
-        print("hey", e)
+        # print("hey", e)
         if e.error_code == HTTPStatus.CONFLICT or "already used by another model instance" in str(e):
             # Instance already exist, creating a new version instead.
             _create_model_instance_version(model_handle, files, version_notes)

--- a/src/kagglehub/models_helpers.py
+++ b/src/kagglehub/models_helpers.py
@@ -60,6 +60,7 @@ def create_model_instance_or_version(
     try:
         _create_model_instance(model_handle, files, license_name)
     except BackendError as e:
+        print("hey", e)
         if e.error_code == HTTPStatus.CONFLICT or "already used by another model instance" in str(e):
             # Instance already exist, creating a new version instead.
             _create_model_instance_version(model_handle, files, version_notes)


### PR DESCRIPTION
I am catching the exception by checking a string, which is not great, not sure how we can catch it otherwise. maybe we can change the exception being thrown on the backend (https://github.com/Kaggle/kaggleazure/blob/8cac02b80ff50d52b95f2863763605ff421e83f9/Kaggle.Services.Models/Utils/ModelInstanceValidator.cs#L134). what do you think?