### PR TITLE
Adds dataset cache resolver

### DIFF
--- a/src/kagglehub/__init__.py
+++ b/src/kagglehub/__init__.py
@@ -11,3 +11,4 @@ registry.model_resolver.add_implementation(kaggle_cache_resolver.ModelKaggleCach
 registry.model_resolver.add_implementation(colab_cache_resolver.ModelColabCacheResolver())
 
 registry.dataset_resolver.add_implementation(http_resolver.DatasetHttpResolver())
+registry.dataset_resolver.add_implementation(kaggle_cache_resolver.DatasetKaggleCacheResolver())

--- a/src/kagglehub/kaggle_cache_resolver.py
+++ b/src/kagglehub/kaggle_cache_resolver.py
@@ -46,13 +46,17 @@ class DatasetKaggleCacheResolver(Resolver[DatasetHandle]):
         if h.is_versioned():
             dataset_ref["VersionNumber"] = str(h.version)
 
-        result = client.post(ATTACH_DATASOURCE_REQUEST_NAME, {
-            "datasetRef": dataset_ref,
-        }, timeout=(DEFAULT_CONNECT_TIMEOUT, ATTACH_DATASOURCE_READ_TIMEOUT))
+        result = client.post(
+            ATTACH_DATASOURCE_REQUEST_NAME,
+            {
+                "datasetRef": dataset_ref,
+            },
+            timeout=(DEFAULT_CONNECT_TIMEOUT, ATTACH_DATASOURCE_READ_TIMEOUT),
+        )
         if "mountSlug" not in result:
             msg = "'result.mountSlug' field missing from response"
             raise BackendError(msg)
-        
+
         base_mount_path = os.getenv(KAGGLE_CACHE_MOUNT_FOLDER_ENV_VAR_NAME, DEFAULT_KAGGLE_CACHE_MOUNT_FOLDER)
         cached_path = f"{base_mount_path}/{result['mountSlug']}"
 
@@ -64,12 +68,12 @@ class DatasetKaggleCacheResolver(Resolver[DatasetHandle]):
                 f"Attaching '{path}' from dataset '{h}' to your Kaggle notebook...",
                 extra={**EXTRA_CONSOLE_BLOCK},
             )
-        
+
         while not os.path.exists(cached_path):
             time.sleep(5)
 
         if path:
-            cached_filepath = f"{cached_path/{path}}"
+            cached_filepath = f"{cached_path}/{path}"
             if not os.path.exists(cached_filepath):
                 msg = (
                     f"'{path}' is not present in the dataset files."

--- a/src/kagglehub/kaggle_cache_resolver.py
+++ b/src/kagglehub/kaggle_cache_resolver.py
@@ -34,14 +34,10 @@ class DatasetKaggleCacheResolver(Resolver[DatasetHandle]):
             return True
 
         return False
+
     def __call__(self, h: DatasetHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False) -> str:
         if force_download:
             logger.warning("Ignoring invalid input: force_download flag cannot be used in a Kaggle notebook")
-
-        if path:
-            logger.info(f"Attaching '{path}' from dataset '{h}' to your Kaggle notebook...")
-        else:
-            logger.info(f"Attaching dataset '{h}' to your Kaggle notebook...")
         client = KaggleJwtClient()
         dataset_ref = {
             "OwnerSlug": h.owner,
@@ -50,33 +46,34 @@ class DatasetKaggleCacheResolver(Resolver[DatasetHandle]):
         if h.is_versioned():
             dataset_ref["VersionNumber"] = str(h.version)
 
-        result = client.post(
-            ATTACH_DATASOURCE_REQUEST_NAME,
-            {
-                "datasetRef": dataset_ref,
-            },
-            timeout=(DEFAULT_CONNECT_TIMEOUT, ATTACH_DATASOURCE_READ_TIMEOUT),
-        )
+        result = client.post(ATTACH_DATASOURCE_REQUEST_NAME, {
+            "datasetRef": dataset_ref,
+        }, timeout=(DEFAULT_CONNECT_TIMEOUT, ATTACH_DATASOURCE_READ_TIMEOUT))
         if "mountSlug" not in result:
             msg = "'result.mountSlug' field missing from response"
             raise BackendError(msg)
-
+        
         base_mount_path = os.getenv(KAGGLE_CACHE_MOUNT_FOLDER_ENV_VAR_NAME, DEFAULT_KAGGLE_CACHE_MOUNT_FOLDER)
         cached_path = f"{base_mount_path}/{result['mountSlug']}"
 
         if not os.path.exists(cached_path):
-            # Only print this if the model is not already mounted.
+            # Only print this if the dataset is not already mounted.
             logger.info(f"Mounting files to {cached_path}...")
-
+        else:
+            logger.info(
+                f"Attaching '{path}' from dataset '{h}' to your Kaggle notebook...",
+                extra={**EXTRA_CONSOLE_BLOCK},
+            )
+        
         while not os.path.exists(cached_path):
             time.sleep(5)
 
         if path:
-            cached_filepath = f"{cached_path}/{path}"
+            cached_filepath = f"{cached_path/{path}}"
             if not os.path.exists(cached_filepath):
                 msg = (
-                    f"'{path}' is not present in the model files. "
-                    f"You can access the other files of the attached model at '{cached_path}'"
+                    f"'{path}' is not present in the dataset files."
+                    f"You can acces the other files othe attached dataset at '{cached_path}'"
                 )
                 raise ValueError(msg)
             return cached_filepath

--- a/src/kagglehub/kaggle_cache_resolver.py
+++ b/src/kagglehub/kaggle_cache_resolver.py
@@ -10,7 +10,7 @@ from kagglehub.clients import (
 from kagglehub.config import is_kaggle_cache_disabled
 from kagglehub.env import is_in_kaggle_notebook
 from kagglehub.exceptions import BackendError
-from kagglehub.handle import ModelHandle
+from kagglehub.handle import DatasetHandle, ModelHandle
 from kagglehub.logger import EXTRA_CONSOLE_BLOCK
 from kagglehub.resolver import Resolver
 
@@ -23,6 +23,64 @@ DEFAULT_KAGGLE_CACHE_MOUNT_FOLDER = "/kaggle/input"
 
 
 logger = logging.getLogger(__name__)
+
+
+class DatasetKaggleCacheResolver(Resolver[DatasetHandle]):
+    def is_supported(self, *_, **__) -> bool:  # noqa: ANN002, ANN003
+        if is_kaggle_cache_disabled():
+            return False
+
+        if is_in_kaggle_notebook():
+            return True
+
+        return False
+    def __call__(self, h: DatasetHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False) -> str:
+        if force_download:
+            logger.warning("Ignoring invalid input: force_download flag cannot be used in a Kaggle notebook")
+
+        if path:
+            logger.info(f"Attaching '{path}' from dataset '{h}' to your Kaggle notebook...")
+        else:
+            logger.info(f"Attaching dataset '{h}' to your Kaggle notebook...")
+        client = KaggleJwtClient()
+        dataset_ref = {
+            "OwnerSlug": h.owner,
+            "DatasetSlug": h.dataset,
+        }
+        if h.is_versioned():
+            dataset_ref["VersionNumber"] = str(h.version)
+
+        result = client.post(
+            ATTACH_DATASOURCE_REQUEST_NAME,
+            {
+                "datasetRef": dataset_ref,
+            },
+            timeout=(DEFAULT_CONNECT_TIMEOUT, ATTACH_DATASOURCE_READ_TIMEOUT),
+        )
+        if "mountSlug" not in result:
+            msg = "'result.mountSlug' field missing from response"
+            raise BackendError(msg)
+
+        base_mount_path = os.getenv(KAGGLE_CACHE_MOUNT_FOLDER_ENV_VAR_NAME, DEFAULT_KAGGLE_CACHE_MOUNT_FOLDER)
+        cached_path = f"{base_mount_path}/{result['mountSlug']}"
+
+        if not os.path.exists(cached_path):
+            # Only print this if the model is not already mounted.
+            logger.info(f"Mounting files to {cached_path}...")
+
+        while not os.path.exists(cached_path):
+            time.sleep(5)
+
+        if path:
+            cached_filepath = f"{cached_path}/{path}"
+            if not os.path.exists(cached_filepath):
+                msg = (
+                    f"'{path}' is not present in the model files. "
+                    f"You can access the other files of the attached model at '{cached_path}'"
+                )
+                raise ValueError(msg)
+            return cached_filepath
+        return cached_path
 
 
 class ModelKaggleCacheResolver(Resolver[ModelHandle]):

--- a/tests/server_stubs/jwt_stub.py
+++ b/tests/server_stubs/jwt_stub.py
@@ -77,6 +77,8 @@ def attach_datasource_using_jwt_request() -> ResponseReturnValue:
             },
         }
         return jsonify(data), 200
+    else:
+        return jsonify(data), 500
 
 
 @contextmanager

--- a/tests/server_stubs/jwt_stub.py
+++ b/tests/server_stubs/jwt_stub.py
@@ -18,6 +18,7 @@ from kagglehub.kaggle_cache_resolver import KAGGLE_CACHE_MOUNT_FOLDER_ENV_VAR_NA
 app = Flask(__name__)
 
 LATEST_MODEL_VERSION = 2
+LATEST_DATASET_VERSION = 2
 
 
 @app.route("/", methods=["HEAD"])
@@ -32,7 +33,32 @@ def error(e: Exception):  # noqa: ANN201
 
 
 @app.route("/kaggle-jwt-handler/AttachDatasourceUsingJwtRequest", methods=["POST"])
-def attach_datasource_using_jwt_request() -> ResponseReturnValue:
+def attach_dataset_datasource_using_jwt_request() -> ResponseReturnValue:
+    data = request.get_json()
+    dataset_ref = data["datasetRef"]
+    version_number = LATEST_DATASET_VERSION
+    if "VersionNumber" in dataset_ref:
+        version_number = dataset_ref["VersionNumber"]
+    mount_slug = f"{dataset_ref['DatasetSlug']}"
+    # # Load the files
+    cache_mount_folder = os.getenv(KAGGLE_CACHE_MOUNT_FOLDER_ENV_VAR_NAME)
+    base_path = f"{cache_mount_folder}/{mount_slug}"
+    os.makedirs(base_path, exist_ok=True)
+    Path(f"{base_path}/foo.txt").touch()
+    if version_number == LATEST_DATASET_VERSION:
+        # The latest version has an extra file.
+        Path(f"{base_path}/bar.csv").touch()
+    data = {
+        "wasSuccessful": True,
+        "result": {
+            "mountSlug": mount_slug,
+        },
+    }
+    return jsonify(data), 200
+
+
+@app.route("/kaggle-jwt-handler/AttachDatasourceUsingJwtRequest", methods=["POST"])
+def attach_model_datasource_using_jwt_request() -> ResponseReturnValue:
     data = request.get_json()
     model_ref = data["modelRef"]
     version_number = LATEST_MODEL_VERSION

--- a/tests/server_stubs/jwt_stub.py
+++ b/tests/server_stubs/jwt_stub.py
@@ -33,53 +33,50 @@ def error(e: Exception):  # noqa: ANN201
 
 
 @app.route("/kaggle-jwt-handler/AttachDatasourceUsingJwtRequest", methods=["POST"])
-def attach_dataset_datasource_using_jwt_request() -> ResponseReturnValue:
+def attach_datasource_using_jwt_request() -> ResponseReturnValue:
     data = request.get_json()
-    dataset_ref = data["datasetRef"]
-    version_number = LATEST_DATASET_VERSION
-    if "VersionNumber" in dataset_ref:
-        version_number = dataset_ref["VersionNumber"]
-    mount_slug = f"{dataset_ref['DatasetSlug']}"
-    # # Load the files
-    cache_mount_folder = os.getenv(KAGGLE_CACHE_MOUNT_FOLDER_ENV_VAR_NAME)
-    base_path = f"{cache_mount_folder}/{mount_slug}"
-    os.makedirs(base_path, exist_ok=True)
-    Path(f"{base_path}/foo.txt").touch()
-    if version_number == LATEST_DATASET_VERSION:
-        # The latest version has an extra file.
-        Path(f"{base_path}/bar.csv").touch()
-    data = {
-        "wasSuccessful": True,
-        "result": {
-            "mountSlug": mount_slug,
-        },
-    }
-    return jsonify(data), 200
-
-
-@app.route("/kaggle-jwt-handler/AttachDatasourceUsingJwtRequest", methods=["POST"])
-def attach_model_datasource_using_jwt_request() -> ResponseReturnValue:
-    data = request.get_json()
-    model_ref = data["modelRef"]
-    version_number = LATEST_MODEL_VERSION
-    if "VersionNumber" in model_ref:
-        version_number = model_ref["VersionNumber"]
-    mount_slug = f"{model_ref['ModelSlug']}/{model_ref['Framework']}/{model_ref['InstanceSlug']}/{version_number}"
-    # # Load the files
-    cache_mount_folder = os.getenv(KAGGLE_CACHE_MOUNT_FOLDER_ENV_VAR_NAME)
-    base_path = f"{cache_mount_folder}/{mount_slug}"
-    os.makedirs(base_path, exist_ok=True)
-    Path(f"{base_path}/config.json").touch()
-    if version_number == LATEST_MODEL_VERSION:
-        # The latest version has an extra file.
-        Path(f"{base_path}/model.keras").touch()
-    data = {
-        "wasSuccessful": True,
-        "result": {
-            "mountSlug": mount_slug,
-        },
-    }
-    return jsonify(data), 200
+    if "modelRef" in data:
+        model_ref = data["modelRef"]
+        version_number = LATEST_MODEL_VERSION
+        if "VersionNumber" in model_ref:
+            version_number = model_ref["VersionNumber"]
+        mount_slug = f"{model_ref['ModelSlug']}/{model_ref['Framework']}/{model_ref['InstanceSlug']}/{version_number}"
+        # # Load the files
+        cache_mount_folder = os.getenv(KAGGLE_CACHE_MOUNT_FOLDER_ENV_VAR_NAME)
+        base_path = f"{cache_mount_folder}/{mount_slug}"
+        os.makedirs(base_path, exist_ok=True)
+        Path(f"{base_path}/config.json").touch()
+        if version_number == LATEST_MODEL_VERSION:
+            # The latest version has an extra file.
+            Path(f"{base_path}/model.keras").touch()
+        data = {
+            "wasSuccessful": True,
+            "result": {
+                "mountSlug": mount_slug,
+            },
+        }
+        return jsonify(data), 200
+    elif "datasetRef" in data:
+        dataset_ref = data["datasetRef"]
+        version_number = LATEST_DATASET_VERSION
+        if "VersionNumber" in dataset_ref:
+            version_number = dataset_ref["VersionNumber"]
+        mount_slug = f"{dataset_ref['DatasetSlug']}"
+        # # Load the files
+        cache_mount_folder = os.getenv(KAGGLE_CACHE_MOUNT_FOLDER_ENV_VAR_NAME)
+        base_path = f"{cache_mount_folder}/{mount_slug}"
+        os.makedirs(base_path, exist_ok=True)
+        Path(f"{base_path}/foo.txt").touch()
+        if version_number == LATEST_DATASET_VERSION:
+            # The latest version has an extra file.
+            Path(f"{base_path}/bar.csv").touch()
+        data = {
+            "wasSuccessful": True,
+            "result": {
+                "mountSlug": mount_slug,
+            },
+        }
+        return jsonify(data), 200
 
 
 @contextmanager

--- a/tests/test_kaggle_cache_dataset_download.py
+++ b/tests/test_kaggle_cache_dataset_download.py
@@ -1,0 +1,29 @@
+import os
+from unittest import mock
+
+import requests
+
+import kagglehub
+from kagglehub.config import DISABLE_KAGGLE_CACHE_ENV_VAR_NAME
+from kagglehub.env import KAGGLE_DATA_PROXY_URL_ENV_VAR_NAME
+from tests.fixtures import BaseTestCase
+
+from .server_stubs import jwt_stub as stub
+from .server_stubs import serv
+
+INVALID_ARCHIVE_DATASET_HANDLE = "test-owner/test-dataset"
+VERSIONED_MODEL_HANDLE = "test-owner/test-dataset/versions/2"
+LATEST_DATASET_VERSION = 2
+UNVERSIONED_DATASET_HANDLE = "test-owner/test-dataset"
+TEST_FILEPATH = "bar.txt"
+
+# Test cases for the DatasetKaggleCacheResolver.
+class TestKaggleCacheDatasetDownload(BaseTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.server = serv.start_server(stub.app, KAGGLE_DATA_PROXY_URL_ENV_VAR_NAME, "http://localhost:7778")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+

--- a/tests/test_kaggle_cache_dataset_download.py
+++ b/tests/test_kaggle_cache_dataset_download.py
@@ -11,11 +11,12 @@ from tests.fixtures import BaseTestCase
 from .server_stubs import jwt_stub as stub
 from .server_stubs import serv
 
-INVALID_ARCHIVE_DATASET_HANDLE = "test-owner/test-dataset"
-VERSIONED_MODEL_HANDLE = "test-owner/test-dataset/versions/2"
+INVALID_ARCHIVE_DATASET_HANDLE = "invalid/invalid/invalid/invalid/invalid"
+VERSIONED_DATASET_HANDLE = "sarahjeffreson/featured-spotify-artiststracks-with-metadata/versions/1"
+UNVERSIONED_DATASET_HANDLE = "sarahjeffreson/featured-spotify-artiststracks-with-metadata"
 LATEST_DATASET_VERSION = 2
-UNVERSIONED_DATASET_HANDLE = "test-owner/test-dataset"
-TEST_FILEPATH = "bar.txt"
+TEST_FILEPATH = "foo.txt"
+
 
 # Test cases for the DatasetKaggleCacheResolver.
 class TestKaggleCacheDatasetDownload(BaseTestCase):
@@ -27,3 +28,59 @@ class TestKaggleCacheDatasetDownload(BaseTestCase):
     def tearDownClass(cls):
         cls.server.shutdown()
 
+    def test_unversioned_dataset_download(self) -> None:
+        with stub.create_env():
+            dataset_path = kagglehub.dataset_download(UNVERSIONED_DATASET_HANDLE)
+            self.assertEqual(["bar.csv", "foo.txt"], sorted(os.listdir(dataset_path)))
+
+    def test_versioned_dataset_download(self) -> None:
+        with stub.create_env():
+            dataset_path = kagglehub.dataset_download(VERSIONED_DATASET_HANDLE)
+            self.assertEqual(["foo.txt"], sorted(os.listdir(dataset_path)))
+
+    def test_versioned_dataset_download_with_path(self) -> None:
+        with stub.create_env():
+            dataset_file_path = kagglehub.dataset_download(VERSIONED_DATASET_HANDLE, "foo.txt")
+            self.assertTrue(dataset_file_path.endswith("foo.txt"))
+            self.assertTrue(os.path.isfile(dataset_file_path))
+
+    def test_unversioned_dataset_download_with_path(self) -> None:
+        with stub.create_env():
+            dataset_file_path = kagglehub.dataset_download(UNVERSIONED_DATASET_HANDLE, "bar.csv")
+            self.assertTrue(dataset_file_path.endswith("bar.csv"))
+            self.assertTrue(os.path.isfile(dataset_file_path))
+
+    def test_versioned_dataset_download_with_missing_file_raises(self) -> None:
+        with stub.create_env():
+            with self.assertRaises(ValueError):
+                kagglehub.dataset_download(VERSIONED_DATASET_HANDLE, "missing.txt")
+
+    def test_unversioned_dataset_download_with_missing_file_raises(self) -> None:
+        with stub.create_env():
+            with self.assertRaises(ValueError):
+                kagglehub.dataset_download(UNVERSIONED_DATASET_HANDLE, "missing.txt")
+
+    def test_kaggle_resolver_skipped(self) -> None:
+        with mock.patch.dict(os.environ, {DISABLE_KAGGLE_CACHE_ENV_VAR_NAME: "true"}):
+            with stub.create_env():
+                # Assert that a ConnectionError is set (uses HTTP server which is not set)
+                with self.assertRaises(requests.exceptions.ConnectionError):
+                    kagglehub.dataset_download(VERSIONED_DATASET_HANDLE)
+
+    def test_versioned_dataset_download_bad_handle_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            kagglehub.dataset_download("bad handle")
+
+    def test_versioned_dataset_download_with_force_download(self) -> None:
+        with stub.create_env():
+            dataset_path = kagglehub.dataset_download(VERSIONED_DATASET_HANDLE)
+            dataset_path_forced = kagglehub.dataset_download(VERSIONED_DATASET_HANDLE, force_download=True)
+
+            # Using force_download shouldn't change the expected output of model_download.
+            self.assertEqual(["foo.txt"], sorted(os.listdir(dataset_path_forced)))
+            self.assertEqual(dataset_path, dataset_path_forced)
+
+    def test_versioned_dataset_download_with_force_download_explicitly_false(self) -> None:
+        with stub.create_env():
+            dataset_path = kagglehub.dataset_download(VERSIONED_DATASET_HANDLE, force_download=False)
+            self.assertEqual(["foo.txt"], sorted(os.listdir(dataset_path)))


### PR DESCRIPTION
Add dataset cache resolver for attaching datasets via kagglehub in a Kaggle Notebook.

[Demo in Kaggle Notebook](https://screencast.googleplex.com/cast/NTQyMDYxODg0NDQ3MTI5NnxhZDVkODk1OC05YQ)

[b/356363103](https://b.corp.google.com/issues/356363103)