### PR TITLE
Try to improve the printing for cached downloads from kaggle/colab

### DIFF
--- a/src/kagglehub/kaggle_cache_resolver.py
+++ b/src/kagglehub/kaggle_cache_resolver.py
@@ -64,7 +64,12 @@ class ModelKaggleCacheResolver(Resolver[ModelHandle]):
 
         if not os.path.exists(cached_path):
             # Only print this if the model is not already mounted.
-            logger.info(f"Mounting files to {cached_path}...", extra={**EXTRA_CONSOLE_BLOCK})
+            logger.info(f"Mounting files to {cached_path}...")
+        else:
+            logger.info(
+                f"Attaching '{path}' from model '{h}' to your Kaggle notebook...",
+                extra={**EXTRA_CONSOLE_BLOCK},
+            )
 
         while not os.path.exists(cached_path):
             time.sleep(5)

--- a/src/kagglehub/kaggle_cache_resolver.py
+++ b/src/kagglehub/kaggle_cache_resolver.py
@@ -65,8 +65,6 @@ class ModelKaggleCacheResolver(Resolver[ModelHandle]):
         if not os.path.exists(cached_path):
             # Only print this if the model is not already mounted.
             logger.info(f"Mounting files to {cached_path}...", extra={**EXTRA_CONSOLE_BLOCK})
-        else:
-            logger.info(f"Attaching '{path}' from model '{h}' to your Kaggle notebook...")
 
         while not os.path.exists(cached_path):
             time.sleep(5)


### PR DESCRIPTION
This is an attempt to fix this issue when running kagglehub from a cache.

![image](https://github.com/user-attachments/assets/4c05a5ab-cc1e-4162-9081-13d1ea129c24)

I don't think we want to log as if we are attaching an asset every time we read something from the cache.

- We have separate UI in Kaggle with a live progress indicate showing how mounting a model is going.
- We might hit `kagglehub` for the same asset multiple times, it shouldn't "attach" each time (nor does it).
- Ideally we don't log anything if we don't find the file being requested.