### PR TITLE
[RFC] Enable empty file uploading

### DIFF
--- a/integration_tests/test_model_upload.py
+++ b/integration_tests/test_model_upload.py
@@ -111,6 +111,15 @@ class TestModelUpload(unittest.TestCase):
             f.write(os.urandom(100))
 
         model_upload(self.handle, str(single_file_path), LICENSE_NAME)
+    
+    def test_model_upload_empty_files(self) -> None:
+        # Create a temp file with empty and non-empty files.
+        test_empty_dir = Path(self.temp_dir) / "test_empty"
+        test_empty_dir.mkdir()
+        (test_empty_dir / "empty.json").touch()
+        (test_empty_dir / "non_empty.json").write_bytes(b"hello")
+
+        model_upload(self.handle, test_empty_dir)
 
     def tearDown(self) -> None:
         models_helpers.delete_model(self.owner_slug, self.model_slug)

--- a/integration_tests/test_model_upload.py
+++ b/integration_tests/test_model_upload.py
@@ -111,7 +111,7 @@ class TestModelUpload(unittest.TestCase):
             f.write(os.urandom(100))
 
         model_upload(self.handle, str(single_file_path), LICENSE_NAME)
-    
+
     def test_model_upload_empty_files(self) -> None:
         # Create a temp file with empty and non-empty files.
         test_empty_dir = Path(self.temp_dir) / "test_empty"

--- a/src/kagglehub/gcs_upload.py
+++ b/src/kagglehub/gcs_upload.py
@@ -157,7 +157,10 @@ def _upload_blob(file_path: str, model_type: str) -> str:
                 uploaded_bytes = _check_uploaded_size(session_uri, file_size)
                 pbar.n = uploaded_bytes  # Update progress bar to reflect actual uploaded bytes
             finally:
-                upload_finished = uploaded_bytes >= file_size or retry_count >= MAX_RETRIES
+                if file_size == 0:
+                    upload_finished = retry_count >= MAX_RETRIES
+                else:
+                    upload_finished = uploaded_bytes >= file_size or retry_count >= MAX_RETRIES
 
     return response["token"]
 


### PR DESCRIPTION
Ref: b/343510166

Previously uploading empty files fails because there is no file created for empty contents (in `gcs_upload.py::_upload_blob` it didn't upload the file when file_size==0). Adding code to support this special case.

Tested
- Added integration test `test_model_upload/test_model_upload_empty_files`. It fails with existing code.
- After code change, the test passes.

