### PR TITLE
[RFC] Implement optional `ignore_patterns` parameter for model upload.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
     "editor.defaultFormatter": "charliermarsh.ruff",
     "[python]": {
         "editor.formatOnSave": true,
+        "editor.defaultFormatter": "ms-python.autopep8",
     },
     "python.testing.pytestArgs": [
         "tests"

--- a/src/kagglehub/gcs_upload.py
+++ b/src/kagglehub/gcs_upload.py
@@ -94,10 +94,12 @@ def _check_uploaded_size(session_uri: str, file_size: int, backoff_factor: int =
 def _upload_blob(file_path: str, model_type: str) -> str:
     """Uploads a file to a remote server as a blob and returns an upload token.
 
-    Parameters
-    ==========
-    file_path: The path to the file to be uploaded.
-    model_type : The type of the model associated with the file.
+    Args:
+        file_path: The path to the file to be uploaded.
+        model_type : The type of the model associated with the file.
+
+    Returns:
+        A str token of uploaded blob.
     """
     file_size = os.path.getsize(file_path)
     data = {
@@ -183,7 +185,7 @@ def upload_files_and_directories(
 
             tokens = [
                 token
-                for token in [_upload_file_or_folder(temp_dir, TEMP_ARCHIVE_FILE, model_type, quiet)]
+                for token in [_upload_file(file_path=zip_path, model_type=model_type, quiet=quiet)]
                 if token is not None
             ]
             return UploadDirectoryInfo(name="archive", files=tokens)
@@ -191,8 +193,7 @@ def upload_files_and_directories(
     root_dict = UploadDirectoryInfo(name="root")
     if os.path.isfile(folder):
         # Directly upload the file if the path is a file
-        file_name = os.path.basename(folder)
-        token = _upload_file_or_folder(os.path.dirname(folder), file_name, model_type, quiet)
+        token = _upload_file(file_path=folder, model_type=model_type, quiet=quiet)
         if token:
             root_dict.files.append(token)
     else:
@@ -217,51 +218,34 @@ def upload_files_and_directories(
 
             # Add file tokens to the current directory in the dictionary
             for file in files:
-                token = _upload_file_or_folder(root, file, model_type, quiet)
+                token = _upload_file(file_path=os.path.join(root, file), model_type=model_type, quiet=quiet)
                 if token:
                     current_dict.files.append(token)
 
     return root_dict
 
 
-def _upload_file_or_folder(
-    parent_path: str,
-    file_or_folder_name: str,
-    model_type: str,
-    quiet: bool = False,  # noqa: FBT002, FBT001
-) -> Optional[str]:
-    """
-    Uploads a file or each file inside a folder individually from a specified path to a remote service.
-    Parameters
-    ==========
-    parent_path: The parent directory path from where the file or folder is to be uploaded.
-    file_or_folder_name: The name of the file or folder to be uploaded.
-    dir_mode: The mode to handle directories. Accepts 'zip', 'tar', or other values for skipping.
-    model_type: Type of the model that is being uploaded.
-    quiet: suppress verbose output (default is False)
-    :return: A token if the upload is successful, or None if the file is skipped or the upload fails.
-    """
-    full_path = os.path.join(parent_path, file_or_folder_name)
-    if os.path.isfile(full_path):
-        return _upload_file(full_path, quiet, model_type)
-    return None
+def _upload_file(file_path: str, *, quiet: bool, model_type: str) -> Optional[str]:
+    """Helper function to upload a single file.
 
+    Args:
+        full_path: path to the file to upload
+        quiet: suppress verbose output
+        model_type: Type of the model that is being uploaded.
 
-def _upload_file(full_path: str, quiet: bool, model_type: str) -> Optional[str]:  # noqa: FBT001
-    """Helper function to upload a single file
-    Parameters
-    ==========
-    full_path: path to the file to upload
-    quiet: suppress verbose output
-    model_type: Type of the model that is being uploaded.
-    :return: None - upload unsuccessful; instance of UploadFile - upload successful
+    Returns:
+        A str token of uploaded file if successful, otherwise None.
     """
 
     if not quiet:
-        logger.info("Starting upload for file " + full_path)
+        logger.info("Starting upload for file " + file_path)
 
-    content_length = os.path.getsize(full_path)
-    token = _upload_blob(full_path, model_type)
+    if not os.path.isfile(file_path):
+        logger.warn("Skip uploading %s because it is not a file.", file_path)
+        return None
+
+    content_length = os.path.getsize(file_path)
+    token = _upload_blob(file_path, model_type)
     if not quiet:
-        logger.info("Upload successful: " + full_path + " (" + File.get_size(content_length) + ")")
+        logger.info("Upload successful: " + file_path + " (" + File.get_size(content_length) + ")")
     return token

--- a/src/kagglehub/gcs_upload.py
+++ b/src/kagglehub/gcs_upload.py
@@ -1,10 +1,12 @@
+import fnmatch
 import logging
 import os
+import pathlib
 import time
 import zipfile
 from datetime import datetime
 from tempfile import TemporaryDirectory
-from typing import Dict, List, Optional, Union
+from typing import Dict, Iterable, List, Optional, Sequence, Union
 
 import requests
 from requests.exceptions import ConnectionError, Timeout
@@ -42,7 +44,8 @@ class UploadDirectoryInfo:
 
 
 def parse_datetime_string(string: str) -> Union[datetime, str]:
-    time_formats = ["%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%dT%H:%M:%S.%fZ"]
+    time_formats = ["%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M:%SZ",
+                    "%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%dT%H:%M:%S.%fZ"]
     for t in time_formats:
         try:
             return datetime.strptime(string[:26], t).replace(microsecond=0)  # noqa: DTZ007
@@ -53,7 +56,8 @@ def parse_datetime_string(string: str) -> Union[datetime, str]:
 
 class File(object):  # noqa: UP004
     def __init__(self, init_dict: dict) -> None:
-        parsed_dict = {k: parse_datetime_string(v) for k, v in init_dict.items()}
+        parsed_dict = {k: parse_datetime_string(
+            v) for k, v in init_dict.items()}
         self.__dict__.update(parsed_dict)
 
     @staticmethod
@@ -66,6 +70,30 @@ class File(object):  # noqa: UP004
         return "%.*f%s" % (precision, size, suffixes[suffix_index])
 
 
+def filtered_walk(*, base_dir: str, ignore_patterns: Sequence[str]) -> Iterable[tuple[str, list[str], list[str]]]:
+    """An `os.walk` like directory tree generator with filtering.
+
+    This method filters out files matching any ignore pattern.
+
+    Args:
+        base_dir (str): The base dir to walk in.
+        ignore_patterns (Sequence[str]):
+            The patterns for ignored files. These are standard wildcards relative to base_dir.
+
+    Yields:
+        Generator[str]: (base_dir_path, List[dir_names], List[file_names])
+    """
+    for dir_path, dir_names, file_names in os.walk(base_dir):
+        dir_p = pathlib.Path(dir_path)
+        filtered_files = []
+        for file_name in file_names:
+            rel_file_p = (dir_p / file_name).relative_to(base_dir)
+            if not any(fnmatch.fnmatch(name=str(rel_file_p), pat=pat) for pat in ignore_patterns):
+                filtered_files.append(file_name)
+        if filtered_files:
+            yield (dir_path, dir_names, filtered_files)
+
+
 def _check_uploaded_size(session_uri: str, file_size: int, backoff_factor: int = 1) -> int:
     """Check the status of the resumable upload."""
     headers = {"Content-Length": "0", "Content-Range": f"bytes */{file_size}"}
@@ -73,7 +101,8 @@ def _check_uploaded_size(session_uri: str, file_size: int, backoff_factor: int =
 
     while retry_count < MAX_RETRIES:
         try:
-            response = requests.put(session_uri, headers=headers, timeout=REQUEST_TIMEOUT)
+            response = requests.put(
+                session_uri, headers=headers, timeout=REQUEST_TIMEOUT)
             if response.status_code == 308:  # Resume Incomplete # noqa: PLR2004
                 range_header = response.headers.get("Range")
                 if range_header:
@@ -83,7 +112,8 @@ def _check_uploaded_size(session_uri: str, file_size: int, backoff_factor: int =
             else:
                 return file_size
         except (ConnectionError, Timeout):
-            logger.info(f"Network issue while checking uploaded size, retrying in {backoff_factor} seconds...")
+            logger.info(
+                f"Network issue while checking uploaded size, retrying in {backoff_factor} seconds...")
             time.sleep(backoff_factor)
             backoff_factor = min(backoff_factor * 2, 60)
             retry_count += 1
@@ -139,19 +169,22 @@ def _upload_blob(file_path: str, model_type: str) -> str:
                     headers["Content-Range"] = f"bytes {uploaded_bytes}-{file_size - 1}/{file_size}"
                     upload_data = CallbackIOWrapper(pbar.update, f, "read")
 
-                upload_response = requests.put(session_uri, headers=headers, data=upload_data, timeout=REQUEST_TIMEOUT)
+                upload_response = requests.put(
+                    session_uri, headers=headers, data=upload_data, timeout=REQUEST_TIMEOUT)
 
                 if upload_response.status_code in [200, 201]:
                     return response["token"]
                 elif upload_response.status_code == 308:  # Resume Incomplete # noqa: PLR2004
-                    uploaded_bytes = _check_uploaded_size(session_uri, file_size)
+                    uploaded_bytes = _check_uploaded_size(
+                        session_uri, file_size)
                 else:
                     upload_failed_exception = (
                         f"Upload failed with status code {upload_response.status_code}: {upload_response.text}"
                     )
                     raise BackendError(upload_failed_exception)
             except (requests.ConnectionError, requests.Timeout) as e:
-                logger.info(f"Network issue: {e}, retrying in {backoff_factor} seconds...")
+                logger.info(
+                    f"Network issue: {e}, retrying in {backoff_factor} seconds...")
                 time.sleep(backoff_factor)
                 backoff_factor = min(backoff_factor * 2, 60)
                 retry_count += 1
@@ -163,25 +196,29 @@ def _upload_blob(file_path: str, model_type: str) -> str:
 
 def upload_files_and_directories(
     folder: str,
+    *,
+    ignore_patterns: Sequence[str],
     model_type: str,
-    quiet: bool = False,  # noqa: FBT002, FBT001
+    quiet: bool = False,
 ) -> UploadDirectoryInfo:
     # Count the total number of files
     file_count = 0
-    for _, _, files in os.walk(folder):
+    for _, _, files in filtered_walk(base_dir=folder, ignore_patterns=ignore_patterns):
         file_count += len(files)
 
     if file_count > MAX_FILES_TO_UPLOAD:
         if not quiet:
-            logger.info(f"More than {MAX_FILES_TO_UPLOAD} files detected, creating a zip archive...")
+            logger.info(
+                f"More than {MAX_FILES_TO_UPLOAD} files detected, creating a zip archive...")
 
         with TemporaryDirectory() as temp_dir:
             zip_path = os.path.join(temp_dir, TEMP_ARCHIVE_FILE)
             with zipfile.ZipFile(zip_path, "w") as zipf:
-                for root, _, files in os.walk(folder):
+                for root, _, files in filtered_walk(base_dir=folder, ignore_patterns=ignore_patterns):
                     for file in files:
                         file_path = os.path.join(root, file)
-                        zipf.write(file_path, os.path.relpath(file_path, folder))
+                        zipf.write(file_path, os.path.relpath(
+                            file_path, folder))
 
             tokens = [
                 token
@@ -193,11 +230,12 @@ def upload_files_and_directories(
     root_dict = UploadDirectoryInfo(name="root")
     if os.path.isfile(folder):
         # Directly upload the file if the path is a file
-        token = _upload_file(file_path=folder, model_type=model_type, quiet=quiet)
+        token = _upload_file(
+            file_path=folder, model_type=model_type, quiet=quiet)
         if token:
             root_dict.files.append(token)
     else:
-        for root, _, files in os.walk(folder):
+        for root, _, files in filtered_walk(base_dir=folder, ignore_patterns=ignore_patterns):
             # Path of the current folder relative to the base folder
             path = os.path.relpath(root, folder)
 
@@ -218,7 +256,8 @@ def upload_files_and_directories(
 
             # Add file tokens to the current directory in the dictionary
             for file in files:
-                token = _upload_file(file_path=os.path.join(root, file), model_type=model_type, quiet=quiet)
+                token = _upload_file(file_path=os.path.join(
+                    root, file), model_type=model_type, quiet=quiet)
                 if token:
                     current_dict.files.append(token)
 
@@ -247,5 +286,6 @@ def _upload_file(file_path: str, *, quiet: bool, model_type: str) -> Optional[st
     content_length = os.path.getsize(file_path)
     token = _upload_blob(file_path, model_type)
     if not quiet:
-        logger.info("Upload successful: " + file_path + " (" + File.get_size(content_length) + ")")
+        logger.info("Upload successful: " + file_path +
+                    " (" + File.get_size(content_length) + ")")
     return token

--- a/src/kagglehub/models_helpers.py
+++ b/src/kagglehub/models_helpers.py
@@ -1,6 +1,6 @@
 import logging
 from http import HTTPStatus
-from typing import Optional
+from typing import List, Optional, Union
 
 from kagglehub.clients import BackendError, KaggleApiV1Client
 from kagglehub.exceptions import KaggleApiHTTPError
@@ -96,3 +96,17 @@ def delete_model(owner_slug: str, model_slug: str) -> None:
             logger.info(f"Could not delete Model '{model_slug}' for user '{owner_slug}'...")
         else:
             raise (e)
+
+
+def _normalize_patterns(*, default: List[str], additional: Union[List[str], str] | None) -> list[str]:
+    """Merge additional patterns to the default, and normalize the dir pattern with wildcard."""
+
+    def add_wildcard_to_dir(pattern: str) -> str:
+        return pattern + "*" if pattern.endswith("/") else pattern
+
+    if additional is None:
+        additional = []
+    elif isinstance(additional, str):
+        additional = [additional]
+
+    return [add_wildcard_to_dir(pattern) for pattern in default + additional]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,63 @@
+"""Test helper functions in kagglehub.
+"""
+
+import pathlib
+import tempfile
+
+from kagglehub import gcs_upload, models_helpers
+from tests.fixtures import BaseTestCase
+
+
+class TesModelsHelpers(BaseTestCase):
+
+    def test_normalize_patterns(self) -> None:
+        default_patterns = [".git/", ".cache/", ".gitignore"]
+        self.assertEqual(
+            models_helpers._normalize_patterns(default=default_patterns, additional=None),
+            [".git/*", ".cache/*", ".gitignore"],
+        )
+        self.assertEqual(
+            models_helpers._normalize_patterns(
+                default=default_patterns, additional=["original/", "*/*.txt", "doc/readme.txt"]
+            ),
+            [".git/*", ".cache/*", ".gitignore", "original/*", "*/*.txt", "doc/readme.txt"],
+        )
+
+    def test_filtered_walk(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir_p = pathlib.Path(tmp_dir)
+
+            # files to upload
+            (tmp_dir_p / "a" / "b").mkdir(parents=True)
+            (tmp_dir_p / "weights.txt").touch()
+            (tmp_dir_p / "a" / "a.txt").touch()
+            (tmp_dir_p / "a" / "b" / "b.txt").touch()
+            (tmp_dir_p / "a" / "b" / ".bb").touch()
+            expected_files = {
+                tmp_dir_p / "weights.txt",
+                tmp_dir_p / "a" / "a.txt",
+                tmp_dir_p / "a" / "b" / "b.txt",
+                tmp_dir_p / "a" / "b" / ".bb",
+            }
+
+            # files to ignore
+            (tmp_dir_p / ".git").mkdir(parents=True)
+            (tmp_dir_p / ".git" / "file").write_text("hidden git file")
+            (tmp_dir_p / ".gitignore").write_text("none")
+
+            (tmp_dir_p / "a" / "b" / ".hidden").touch()
+
+            (tmp_dir_p / "original" / "fp8").mkdir(parents=True)
+            (tmp_dir_p / "original" / "fp8" / "weights").touch()
+            (tmp_dir_p / "original" / "fp16").mkdir(parents=True)
+            (tmp_dir_p / "original" / "fp16" / "weights").touch()
+
+            # filtered walk
+            ignore_patterns = models_helpers._normalize_patterns(
+                default=[".git/", ".gitignore", "*/.hidden", "original/"], additional=None
+            )
+            walked_files = []
+            for dir_path, _, file_names in gcs_upload.filtered_walk(base_dir=tmp_dir, ignore_patterns=ignore_patterns):
+                for file_name in file_names:
+                    walked_files.append(pathlib.Path(dir_path) / file_name)
+            self.assertEqual(set(walked_files), expected_files)

--- a/tests/test_model_upload.py
+++ b/tests/test_model_upload.py
@@ -72,7 +72,8 @@ class TestModelUpload(BaseTestCase):
             self.assertIn(TEMP_ARCHIVE_FILE, stub.shared_data.files)
 
     def test_model_upload_resumable(self) -> None:
-        stub.simulate_308(state=True)  # Enable simulation of 308 response for this test
+        # Enable simulation of 308 response for this test
+        stub.simulate_308(state=True)
         with TemporaryDirectory() as temp_dir:
             test_filepath = Path(temp_dir) / TEMP_TEST_FILE
             test_filepath.touch()
@@ -142,3 +143,41 @@ class TestModelUpload(BaseTestCase):
             # TODO: Add assertions on CreateModelInstanceRequest.Directories and
             # CreateModelInstanceRequest.Files to verify the expected structure
             # is sent.
+
+    def test_model_upload_with_ignore_patterns(self) -> None:
+        with TemporaryDirectory() as tmp_dir:
+            tmp_dir_p = Path(tmp_dir)
+            # files to upload
+            (tmp_dir_p / "a" / "b").mkdir(parents=True)
+            (tmp_dir_p / "weights.txt").touch()
+            (tmp_dir_p / "a" / "a.txt").touch()
+            (tmp_dir_p / "a" / "b" / "b.txt").touch()
+            (tmp_dir_p / "a" / "b" / ".bb").touch()
+            expected_files = {
+                "weights.txt",
+                "a.txt",
+                "b.txt",
+                ".bb",
+            }
+
+            # files to ignore
+            (tmp_dir_p / ".git").mkdir(parents=True)
+            (tmp_dir_p / ".git" / "file").write_text("hidden git file")
+            (tmp_dir_p / ".gitignore").write_text("none")
+
+            (tmp_dir_p / "a" / "b" / ".hidden").touch()
+
+            (tmp_dir_p / "original" / "fp8").mkdir(parents=True)
+            (tmp_dir_p / "original" / "fp8" / "weights").touch()
+            (tmp_dir_p / "original" / "fp16").mkdir(parents=True)
+            (tmp_dir_p / "original" / "fp16" / "weights").touch()
+
+            # .git is already ignored by default
+            ignore_patterns = [".gitignore", "*/.hidden", "original/"]
+            model_upload(
+                handle="metaresearch/testmodel/pytorch/withignore",
+                local_model_dir=tmp_dir,
+                ignore_patterns=ignore_patterns,
+            )
+            self.assertEqual(len(stub.shared_data.files), len(expected_files))
+            self.assertEqual(set(stub.shared_data.files), expected_files)


### PR DESCRIPTION
**Changes:**
- Refactored `gcs_upload.py` for simplicity (let me know if this better be in a separate PR): 
  - removed unnecessary method `_upload_file_or_folder`
  - Fix formating based on pep8
- Implemented `ignore_patterns` for `model_upload` 
  - The patterns are standard wildcard, consistent with huggingface api (https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/utils/_paths.py#L52)
  - Provides a default ignore list as `models.DEFAULT_IGNORE_PATTERNS`
  - The final pattern list is `DEFAULT_IGNORE_PATTERNS` + `ignore_patterns` (user provided). This is consistent with hf api (https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/hf_api.py#L4854)
- Added tests for both helper functions and model upload with ignore_patterns

**TODO:**
- Update documents

FIX=354710562
Tested (end to end)
  - Local model structure
<img width="500" alt="Screenshot 2024-07-26 at 1 14 28 PM" src="https://github.com/user-attachments/assets/e322d628-7d46-4340-aa67-f478bdbf28b1">

  - Upload command: `kagglehub.model_upload("limakaggle/testignore/pytorch/2", "/tmp/ignoremodel", ignore_patterns=["original/", ".gitattribute"])`
 
  - Uploaded model
<img width="281" alt="Screenshot 2024-07-26 at 1 15 58 PM" src="https://github.com/user-attachments/assets/c00bb231-26f1-4eee-ac3b-1fc449017d98">