### PR TITLE
[API] Add keras to user agent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ requires-python = ">=3.7"
 dependencies = [
   "requests", 
   "tqdm",
-  "packaging"
+  "packaging",
+  "importlib_metadata; python_version < '3.8'"
 ]
 
 [project.urls]

--- a/src/kagglehub/env.py
+++ b/src/kagglehub/env.py
@@ -34,7 +34,7 @@ def is_in_kaggle_notebook() -> bool:
     return False
 
 
-@functools.cache
+@functools.lru_cache(maxsize=None)
 def read_kaggle_build_date() -> str:
     build_date_file = "/etc/build_date"
     try:

--- a/src/kagglehub/env.py
+++ b/src/kagglehub/env.py
@@ -1,4 +1,9 @@
-import importlib.metadata
+try:
+    # For Python 3.8 and above
+    from importlib import metadata  # type: ignore
+except ImportError:
+    # For Python 3.7 and below
+    import importlib_metadata as metadata  # type: ignore
 import inspect
 import logging
 import os
@@ -59,8 +64,8 @@ def search_lib_in_call_stack(lib_name: str) -> Optional[str]:
 
         if module_name is not None and re.match(lib_name, module_name):
             try:
-                lib_version = importlib.metadata.version(lib_name)
+                lib_version = metadata.version(lib_name)
                 return f"{lib_name}/{lib_version}"
-            except importlib.metadata.PackageNotFoundError:
+            except metadata.PackageNotFoundError:
                 continue
     return None

--- a/src/kagglehub/env.py
+++ b/src/kagglehub/env.py
@@ -4,10 +4,10 @@ try:
 except ImportError:
     # For Python 3.7 and below
     import importlib_metadata as metadata  # type: ignore
+import functools
 import inspect
 import logging
 import os
-import re
 from typing import Optional
 
 KAGGLE_NOTEBOOK_ENV_VAR_NAME = "KAGGLE_KERNEL_RUN_TYPE"
@@ -34,6 +34,7 @@ def is_in_kaggle_notebook() -> bool:
     return False
 
 
+@functools.cache
 def read_kaggle_build_date() -> str:
     build_date_file = "/etc/build_date"
     try:
@@ -50,7 +51,7 @@ def search_lib_in_call_stack(lib_name: str) -> Optional[str]:
     Args:
         lib_name (str):
             The name of the library to search for.
-            We use re.match so the lib_name must match the module name from beginning.
+            We use str.startswith so the lib_name must match the exact module name from beginning.
 
     Returns:
         str: A formatted string f"{lib_name}/{lib_version}" if found, otherwise None.
@@ -62,7 +63,7 @@ def search_lib_in_call_stack(lib_name: str) -> Optional[str]:
         else:
             module_name = None
 
-        if module_name is not None and re.match(lib_name, module_name):
+        if module_name is not None and module_name.startswith(lib_name):
             try:
                 lib_version = metadata.version(lib_name)
                 return f"{lib_name}/{lib_version}"

--- a/tests/test_kaggle_api_client.py
+++ b/tests/test_kaggle_api_client.py
@@ -1,6 +1,8 @@
 import os
 from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock, patch
 
+from kagglehub import clients
 from kagglehub.clients import KaggleApiV1Client
 from kagglehub.exceptions import DataCorruptionError
 from tests.fixtures import BaseTestCase
@@ -64,3 +66,40 @@ class TestKaggleApiV1Client(BaseTestCase):
 
             # Assert the corrupted file has been deleted.
             self.assertFalse(os.path.exists(out_file))
+
+    @patch.dict("os.environ", {})
+    def test_get_user_agent(self) -> None:
+        self.assertEqual(clients.get_user_agent(), "kagglehub/0.2.9")
+
+    @patch.dict(
+        "os.environ", {"KAGGLE_KERNEL_RUN_TYPE": "Interactive", "KAGGLE_DATA_PROXY_URL": "https://dp.kaggle.net"}
+    )
+    def test_get_user_agent_kkb(self) -> None:
+        self.assertEqual(clients.get_user_agent(), "kagglehub/0.2.9 kkb/unknown")
+
+    @patch.dict(
+        "os.environ",
+        {
+            "COLAB_RELEASE_TAG": "release-colab-20230531-060125-RC00",
+        },
+    )
+    def test_get_user_agent_colab(self) -> None:
+        self.assertEqual(clients.get_user_agent(), "kagglehub/0.2.9 colab/release-colab-20230531-060125-RC00-unmanaged")
+
+    @patch("importlib.metadata.version")
+    @patch("inspect.ismodule")
+    @patch("inspect.stack")
+    def test_get_user_agent_keras_nlp(
+        self, mock_stack: MagicMock, mock_is_module: MagicMock, mock_version: MagicMock
+    ) -> None:
+        # Mock the call stack and version information.
+        mock_stack.return_value = [
+            MagicMock(frame=MagicMock(__name__="kagglehub.clients")),
+            MagicMock(frame=MagicMock(__name__="kagglehub.models_helpers")),
+            MagicMock(frame=MagicMock(__name__="kagglehub.models")),
+            MagicMock(frame=MagicMock(__name__="keras_nlp.src.utils.preset_utils")),
+            MagicMock(frame=MagicMock(None)),
+        ]
+        mock_is_module.return_value = True
+        mock_version.return_value = "0.15.0"
+        self.assertEqual(clients.get_user_agent(), "kagglehub/0.2.9 keras_nlp/0.15.0")

--- a/tests/test_kaggle_api_client.py
+++ b/tests/test_kaggle_api_client.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch
 
@@ -9,6 +10,13 @@ from tests.fixtures import BaseTestCase
 
 from .server_stubs import kaggle_api_stub as stub
 from .server_stubs import serv
+
+
+def _patch_metadata_version():  # noqa: ANN202
+    if sys.version_info >= (3, 8):
+        return patch("importlib.metadata.version")
+    else:
+        return patch("importlib_metadata.version")
 
 
 class TestKaggleApiV1Client(BaseTestCase):
@@ -86,7 +94,7 @@ class TestKaggleApiV1Client(BaseTestCase):
     def test_get_user_agent_colab(self) -> None:
         self.assertEqual(clients.get_user_agent(), "kagglehub/0.2.9 colab/release-colab-20230531-060125-RC00-unmanaged")
 
-    @patch("importlib.metadata.version")
+    @_patch_metadata_version()
     @patch("inspect.ismodule")
     @patch("inspect.stack")
     def test_get_user_agent_keras_nlp(


### PR DESCRIPTION
Enable tracking of keras model upload via kagglehub api. This is the change for kagglehub part. PR for midtier change is http://go/kaggle-pr/30947

Discussion: [MM](https://chat.kaggle.net/kaggle/pl/koqfqp1s7fbbpgbef595g7ahxy)

FIX=b/343245882
Tested
- Tested via python, kkb and colab.google.com: [code](http://gpaste/6607430098354176#l=8)
- Confirmed the model was created with [expected referrer](http://screen/7AHEiJyFipP3XTH): http://scripts/script_db._994980_6fc6_4beb_b125_96ae171762f9