### PR TITLE
[Tool] Migrate tests to build in hatch test.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG PYTHON_VERSION
 
 FROM python:${PYTHON_VERSION}
 
-RUN pip install hatch==1.9.4
+RUN pip install hatch
 
 # Add only the minimal files required to be able to pre-create the hatch environments.
 # If any of these files changes, a new Docker build is necessary. This is why we need

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG PYTHON_VERSION
 
 FROM python:${PYTHON_VERSION}
 
-RUN pip install hatch
+RUN pip install hatch==1.12.0
 
 # Add only the minimal files required to be able to pre-create the hatch environments.
 # If any of these files changes, a new Docker build is necessary. This is why we need

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ hatch run lint:fmt
 ### Coverage report
 
 ```sh
-hatch test -x py=3.7 --cover
+hatch test --cover
 ```
 
 ### Build

--- a/README.md
+++ b/README.md
@@ -153,11 +153,14 @@ Follow these [instructions](https://hatch.pypa.io/latest/install/) to install it
 ### Tests
 
 ```sh
-# Run all tests
-hatch run test
+# Run all tests for all Python versions.
+hatch test --all
+
+# Run all tests for a specific Python version.
+hatch test -py 3.11
 
 # Run a single test file
-hatch run test tests/test_<SOME_FILE>.py
+hatch test tests/test_<SOME_FILE>.py
 ```
 
 ### Integration Tests
@@ -170,7 +173,7 @@ After setting up your credentials by any of these methods, you can run the integ
 
 ```sh
 # Run all tests
-hatch run integration-test
+hatch test integration_tests
 ```
 
 
@@ -196,7 +199,7 @@ hatch run lint:fmt
 ### Coverage report
 
 ```sh
-hatch cov
+hatch test -x py=3.7 --cover
 ```
 
 ### Build

--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ Follow these [instructions](https://hatch.pypa.io/latest/install/) to install it
 ### Tests
 
 ```sh
+# Run all tests for current Python version.
+hatch test
+
 # Run all tests for all Python versions.
 hatch test --all
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ The following shows how to run `hatch run lint:all` but this also works for any 
 
 # Use specific Python version (Must be a valid tag from: https://hub.docker.com/_/python)
 ./docker-hatch -v 3.9 run lint:all
+
+# Run test in docker with specific Python version
+./docker-hatch -v 3.9 test
 ```
 
 ## VS Code setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,9 @@ python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 [[tool.hatch.envs.all.matrix]]
 python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
+[[tool.hatch.envs.lint.matrix]]
+python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
+
 [tool.hatch.envs.lint]
 detached = true
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 keywords = ["Kaggle", "API"]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = [
   "requests", 
   "tqdm",
@@ -34,7 +34,7 @@ dependencies = [
 [tool.hatch.version]
 path = "src/kagglehub/__init__.py"
 
-[tool.hatch.envs.default]
+[tool.hatch.envs.hatch-test]
 dependencies = [
   "coverage[toml]>=6.5",
   "pytest",
@@ -42,35 +42,14 @@ dependencies = [
   "flask-jwt-extended",
 ]
 
-[tool.hatch.envs.default.scripts]
-test = "pytest {args:tests}"
-integration-test = "pytest {args:integration_tests}"
-test-cov = "coverage run -m pytest {args:tests integration_tests}"
-cov-report = [
-  "- coverage combine",
-  "coverage report",
-]
-cov = [
-  "test-cov",
-  "cov-report",
-]
-
-[tool.hatch.envs.hatch-test]
-dependencies = [
-  "coverage[toml]>=6.5; python_version >= '3.8'",
-  "pytest",
-  "flask",
-  "flask-jwt-extended",
-]
-
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
+python = ["3.9", "3.10", "3.11"]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
+python = ["3.9", "3.10", "3.11"]
 
 [[tool.hatch.envs.lint.matrix]]
-python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
+python = ["3.9", "3.10", "3.11"]
 
 [tool.hatch.envs.lint]
 detached = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,6 @@ python = ["3.9", "3.10", "3.11", "3.12"]
 [[tool.hatch.envs.all.matrix]]
 python = ["3.9", "3.10", "3.11", "3.12"]
 
-[[tool.hatch.envs.lint.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12"]
-
 [tool.hatch.envs.lint]
 detached = true
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,17 @@ cov = [
   "cov-report",
 ]
 
+[tool.hatch.envs.hatch-test]
+dependencies = [
+  "coverage[toml]>=6.5; python_version >= '3.8'",
+  "pytest",
+  "flask",
+  "flask-jwt-extended",
+]
+
+[[tool.hatch.envs.hatch-test.matrix]]
+python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
+
 [[tool.hatch.envs.all.matrix]]
 python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,13 +43,13 @@ dependencies = [
 ]
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.9", "3.10", "3.11"]
+python = ["3.9", "3.10", "3.11", "3.12"]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.9", "3.10", "3.11"]
+python = ["3.9", "3.10", "3.11", "3.12"]
 
 [[tool.hatch.envs.lint.matrix]]
-python = ["3.9", "3.10", "3.11"]
+python = ["3.9", "3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.lint]
 detached = true

--- a/tools/cicd/Dockerfile
+++ b/tools/cicd/Dockerfile
@@ -6,6 +6,6 @@ ARG PYTHON_VERSION
 
 FROM python:${PYTHON_VERSION}
 
-RUN python -m pip install hatch==1.12.0 twine
+RUN python -m pip install hatch twine
 
 ENTRYPOINT ["hatch"]

--- a/tools/cicd/Dockerfile
+++ b/tools/cicd/Dockerfile
@@ -6,6 +6,6 @@ ARG PYTHON_VERSION
 
 FROM python:${PYTHON_VERSION}
 
-RUN python -m pip install hatch twine
+RUN python -m pip install hatch==1.12.0 twine
 
 ENTRYPOINT ["hatch"]

--- a/tools/cicd/cloudbuild.yaml
+++ b/tools/cicd/cloudbuild.yaml
@@ -39,6 +39,7 @@ steps:
   id: lint
   args:
   - run
+  - +py=${_PYTHON_VERSION}
   - lint:all
   waitFor: ['build-hatch-image']
 

--- a/tools/cicd/cloudbuild.yaml
+++ b/tools/cicd/cloudbuild.yaml
@@ -32,7 +32,6 @@ steps:
 - name: us-docker.pkg.dev/$PROJECT_ID/tools/hatch:${_PYTHON_VERSION}
   id: tests
   args:
-  - run
   - test
   waitFor: ['build-hatch-image']
 

--- a/tools/cicd/cloudbuild.yaml
+++ b/tools/cicd/cloudbuild.yaml
@@ -39,7 +39,6 @@ steps:
   id: lint
   args:
   - run
-  - "+py=${_PYTHON_VERSION%.*}"
   - lint:all
   waitFor: ['build-hatch-image']
 

--- a/tools/cicd/cloudbuild.yaml
+++ b/tools/cicd/cloudbuild.yaml
@@ -39,7 +39,7 @@ steps:
   id: lint
   args:
   - run
-  - +py=${_PYTHON_VERSION%.*}
+  - "+py=${_PYTHON_VERSION%.*}"
   - lint:all
   waitFor: ['build-hatch-image']
 

--- a/tools/cicd/cloudbuild.yaml
+++ b/tools/cicd/cloudbuild.yaml
@@ -39,7 +39,7 @@ steps:
   id: lint
   args:
   - run
-  - +py=${_PYTHON_VERSION}
+  - +py=${_PYTHON_VERSION%.*}
   - lint:all
   waitFor: ['build-hatch-image']
 

--- a/tools/cicd/integration-tests.yaml
+++ b/tools/cicd/integration-tests.yaml
@@ -43,7 +43,7 @@ steps:
       export KAGGLE_USERNAME
       export KAGGLE_KEY
       source /root/secrets.sh
-      hatch run integration-test
+      hatch test integration_tests
     volumes:
     - name: 'root'
       path: /root


### PR DESCRIPTION
Migrate from "hatch run test" script to "hatch test" builtin. Also migrate kagglehub off python 3.8- support.

- Hatch 1.10+ supports builtin test by `hatch-test` env. This has several pros compared to our own implementation of tests as scripts. Details in the task. We removed the current test script but keep the docker-hatch functionality.
- Stop support for python 3.7/3.8 so the api/tool usage is much clearer. TODO: migrate python code (b/360894076)


FIX=b/353580550

Tested
- Test all python versions: `hatch test --all`
- Test specific python versions: `hatch test -i py=3.11`
- Integration tests: `hatch test integration_tests -py 3.9`
