### PR TITLE
Upgrade code base to Python 3.9+

### DIFF
--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -1,8 +1,8 @@
 import os
 import unittest
+from collections.abc import Generator
 from contextlib import contextmanager
 from tempfile import TemporaryDirectory
-from typing import Generator, List
 from unittest import mock
 
 from kagglehub.config import CACHE_FOLDER_ENV_VAR_NAME, KEY_ENV_VAR_NAME, USERNAME_ENV_VAR_NAME
@@ -15,7 +15,7 @@ def create_test_cache() -> Generator[str, None, None]:
             yield d
 
 
-def list_files_recursively(path: str) -> List[str]:
+def list_files_recursively(path: str) -> list[str]:
     """List all files recursively in the given path.
     If the path is a file, return a list containing only that file.
     If the path is a directory, list all files recursively in that directory."""
@@ -32,7 +32,7 @@ def list_files_recursively(path: str) -> List[str]:
     return sorted(files)
 
 
-def assert_files(test_case: unittest.TestCase, path: str, expected_files: List[str]) -> bool:
+def assert_files(test_case: unittest.TestCase, path: str, expected_files: list[str]) -> bool:
     """Assert that all expected files exist and are non-empty."""
     files = list_files_recursively(path)
     expected_files_sorted = sorted(expected_files)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,6 @@ python = ["3.9", "3.10", "3.11", "3.12"]
 [[tool.hatch.envs.all.matrix]]
 python = ["3.9", "3.10", "3.11", "3.12"]
 
-# TODO: remove this for lint for now
-[[tool.hatch.envs.lint.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12"]
-
 [tool.hatch.envs.lint]
 detached = true
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
   "requests", 
   "tqdm",
   "packaging",
-  "importlib_metadata; python_version < '3.8'"
 ]
 
 [project.urls]
@@ -46,6 +45,10 @@ dependencies = [
 python = ["3.9", "3.10", "3.11", "3.12"]
 
 [[tool.hatch.envs.all.matrix]]
+python = ["3.9", "3.10", "3.11", "3.12"]
+
+# TODO: remove this for lint for now
+[[tool.hatch.envs.lint.matrix]]
 python = ["3.9", "3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.lint]
@@ -78,12 +81,12 @@ all = [
 ]
 
 [tool.black]
-target-version = ["py37"]
+target-version = ["py39"]
 line-length = 120
 skip-string-normalization = true
 
 [tool.ruff]
-target-version = "py37"
+target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]

--- a/src/kagglehub/auth.py
+++ b/src/kagglehub/auth.py
@@ -1,7 +1,7 @@
 import io
 import logging
+from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Generator
 
 from kagglehub.clients import KaggleApiV1Client
 from kagglehub.config import get_kaggle_credentials, set_kaggle_credentials

--- a/src/kagglehub/clients.py
+++ b/src/kagglehub/clients.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional
 from urllib.parse import urljoin
 
 import requests
@@ -251,7 +251,7 @@ class KaggleJwtClient:
         self,
         request_name: str,
         data: dict,
-        timeout: Tuple[float, float] = (DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT),
+        timeout: tuple[float, float] = (DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT),
     ) -> dict:
         url = f"{self.endpoint}{KaggleJwtClient.BASE_PATH}{request_name}"
         with requests.post(

--- a/src/kagglehub/datasets.py
+++ b/src/kagglehub/datasets.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from kagglehub import registry
 from kagglehub.datasets_helpers import create_dataset_or_version
@@ -32,14 +32,14 @@ def dataset_upload(
     handle: str,
     local_dataset_dir: str,
     version_notes: str = "",
-    ignore_patterns: Optional[Union[List[str], str]] = None,
+    ignore_patterns: Optional[Union[list[str], str]] = None,
 ) -> None:
     """Upload dataset files.
     Args:
         handle: (string) the dataset handle.
         local_dataset_dir: (string) path to a file in a local directory.
         version_notes: (string) Optional to write dataset versions.
-        ignore_patterns (str or List[str], optional):
+        ignore_patterns (str or list[str], optional):
             Additional ignore patterns to DEFAULT_IGNORE_PATTERNS.
             Files matching any of the patterns are not uploaded.
             Patterns are standard wildcards that can be matched by

--- a/src/kagglehub/env.py
+++ b/src/kagglehub/env.py
@@ -1,13 +1,8 @@
-try:
-    # For Python 3.8 and above
-    from importlib import metadata  # type: ignore
-except ImportError:
-    # For Python 3.7 and below
-    import importlib_metadata as metadata  # type: ignore
 import functools
 import inspect
 import logging
 import os
+from importlib import metadata  # type: ignore
 from typing import Optional
 
 KAGGLE_NOTEBOOK_ENV_VAR_NAME = "KAGGLE_KERNEL_RUN_TYPE"
@@ -34,7 +29,7 @@ def is_in_kaggle_notebook() -> bool:
     return False
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def read_kaggle_build_date() -> str:
     build_date_file = "/etc/build_date"
     try:

--- a/src/kagglehub/exceptions.py
+++ b/src/kagglehub/exceptions.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 import requests
 
@@ -103,7 +103,7 @@ def colab_raise_for_status(response: requests.Response, resource_handle: Optiona
         raise ColabHTTPError(message, response=response) from e
 
 
-def process_post_response(response: Dict[str, Any]) -> None:
+def process_post_response(response: dict[str, Any]) -> None:
     """
     Postprocesses the API response to check for errors.
     """

--- a/src/kagglehub/gcs_upload.py
+++ b/src/kagglehub/gcs_upload.py
@@ -4,9 +4,10 @@ import os
 import pathlib
 import time
 import zipfile
+from collections.abc import Iterable, Sequence
 from datetime import datetime
 from tempfile import TemporaryDirectory
-from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Optional, Union
 
 import requests
 from requests.exceptions import ConnectionError, Timeout
@@ -28,14 +29,14 @@ class UploadDirectoryInfo:
     def __init__(
         self,
         name: str,
-        files: Optional[List[str]] = None,
-        directories: Optional[List["UploadDirectoryInfo"]] = None,
+        files: Optional[list[str]] = None,
+        directories: Optional[list["UploadDirectoryInfo"]] = None,
     ):
         self.name = name
         self.files = files if files is not None else []
         self.directories = directories if directories is not None else []
 
-    def serialize(self) -> Dict:
+    def serialize(self) -> dict:
         return {
             "name": self.name,
             "files": [{"token": file} for file in self.files],
@@ -68,7 +69,7 @@ class File(object):  # noqa: UP004
         return "%.*f%s" % (precision, size, suffixes[suffix_index])
 
 
-def filtered_walk(*, base_dir: str, ignore_patterns: Sequence[str]) -> Iterable[Tuple[str, List[str], List[str]]]:
+def filtered_walk(*, base_dir: str, ignore_patterns: Sequence[str]) -> Iterable[tuple[str, list[str], list[str]]]:
     """An `os.walk` like directory tree generator with filtering.
 
     This method filters out files matching any ignore pattern.
@@ -79,7 +80,7 @@ def filtered_walk(*, base_dir: str, ignore_patterns: Sequence[str]) -> Iterable[
             The patterns for ignored files. These are standard wildcards relative to base_dir.
 
     Yields:
-        Iterable[tuple[str, list[str], list[str]]]: (base_dir_path, List[dir_names], List[filtered_file_names])
+        Iterable[tuple[str, list[str], list[str]]]: (base_dir_path, list[dir_names], list[filtered_file_names])
     """
     for dir_path, dir_names, file_names in os.walk(base_dir):
         dir_p = pathlib.Path(dir_path)
@@ -279,7 +280,7 @@ def _upload_file(file_path: str, *, quiet: bool, item_type: str) -> Optional[str
     return token
 
 
-def normalize_patterns(*, default: List[str], additional: Optional[Union[List[str], str]]) -> List[str]:
+def normalize_patterns(*, default: list[str], additional: Optional[Union[list[str], str]]) -> list[str]:
     """Merges additional patterns with the default, and normalize the dir pattern with wildcard."""
 
     def add_wildcard_to_dir(pattern: str) -> str:

--- a/src/kagglehub/http_resolver.py
+++ b/src/kagglehub/http_resolver.py
@@ -2,7 +2,7 @@ import logging
 import os
 import tarfile
 import zipfile
-from typing import List, Optional, Tuple
+from typing import Optional
 
 from tqdm.contrib.concurrent import thread_map
 
@@ -169,7 +169,7 @@ def _get_current_version(api_client: KaggleApiV1Client, h: ResourceHandle) -> in
         raise ValueError(msg)
 
 
-def _list_files(api_client: KaggleApiV1Client, h: ModelHandle) -> Tuple[List[str], bool]:
+def _list_files(api_client: KaggleApiV1Client, h: ModelHandle) -> tuple[list[str], bool]:
     json_response = api_client.get(_build_list_model_instance_version_files_url_path(h), h)
     if "files" not in json_response:
         msg = "Invalid ListModelInstanceVersionFiles API response. Expected to include a 'files' field"

--- a/src/kagglehub/logger.py
+++ b/src/kagglehub/logger.py
@@ -3,7 +3,7 @@ import sys
 from logging import LogRecord
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from typing import Callable, List, Optional
+from typing import Callable, Optional
 
 from kagglehub.config import get_log_verbosity
 
@@ -13,7 +13,7 @@ _CONSOLE_BLOCK_KEY = "console"
 EXTRA_CONSOLE_BLOCK = {"block": _CONSOLE_BLOCK_KEY}
 
 
-def _block_logrecord_factory(elements: List[str]) -> Callable[[LogRecord], bool]:
+def _block_logrecord_factory(elements: list[str]) -> Callable[[LogRecord], bool]:
     """Filter to block log statements based on data attributes
     Args:
         elements: The value for the key 'block'. For example log.info("..", extra={"block" : "console"})

--- a/src/kagglehub/models.py
+++ b/src/kagglehub/models.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from kagglehub import registry
 from kagglehub.gcs_upload import normalize_patterns, upload_files_and_directories
@@ -35,7 +35,7 @@ def model_upload(
     local_model_dir: str,
     license_name: Optional[str] = None,
     version_notes: str = "",
-    ignore_patterns: Optional[Union[List[str], str]] = None,
+    ignore_patterns: Optional[Union[list[str], str]] = None,
 ) -> None:
     """Upload model files.
 
@@ -44,7 +44,7 @@ def model_upload(
         local_model_dir: (str) path to a file in a local directory.
         license_name: (str) model license.
         version_notes: (str, optional) model versions.
-        ignore_patterns (str or List[str], optional):
+        ignore_patterns (str or list[str], optional):
             Additional ignore patterns to DEFAULT_IGNORE_PATTERNS.
             Files matching any of the patterns are not uploaded.
             Patterns are standard wildcards that can be matched by

--- a/src/kagglehub/registry.py
+++ b/src/kagglehub/registry.py
@@ -1,4 +1,4 @@
-from typing import Callable, List
+from typing import Callable
 
 
 class MultiImplRegistry:
@@ -11,7 +11,7 @@ class MultiImplRegistry:
 
     def __init__(self, name: str) -> None:
         self._name = name
-        self._impls: List[Callable] = []
+        self._impls: list[Callable] = []
 
     def add_implementation(self, impl: Callable) -> None:
         self._impls += [impl]

--- a/tests/server_stubs/colab_stub.py
+++ b/tests/server_stubs/colab_stub.py
@@ -1,8 +1,9 @@
 import os
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Generator
+from typing import Any
 from unittest import mock
 
 from flask import Flask, jsonify, request

--- a/tests/server_stubs/dataset_download_stub.py
+++ b/tests/server_stubs/dataset_download_stub.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
-from typing import Any, Generator
+from collections.abc import Generator
+from typing import Any
 
 from flask import Flask, Response, jsonify
 from flask.typing import ResponseReturnValue

--- a/tests/server_stubs/dataset_upload_stub.py
+++ b/tests/server_stubs/dataset_upload_stub.py
@@ -1,6 +1,5 @@
 import threading
 from dataclasses import dataclass, field
-from typing import List
 
 from flask import Flask, jsonify, request
 from flask.typing import ResponseReturnValue
@@ -12,7 +11,7 @@ app = Flask(__name__)
 
 @dataclass
 class SharedData:
-    files: List[str] = field(default_factory=list)
+    files: list[str] = field(default_factory=list)
     simulate_308: bool = False
     blob_request_count: int = 0
 

--- a/tests/server_stubs/jwt_stub.py
+++ b/tests/server_stubs/jwt_stub.py
@@ -1,8 +1,9 @@
 import os
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Generator
+from typing import Any
 from unittest import mock
 
 from flask import Flask, jsonify, request

--- a/tests/server_stubs/model_download_stub.py
+++ b/tests/server_stubs/model_download_stub.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
-from typing import Any, Generator
+from collections.abc import Generator
+from typing import Any
 
 from flask import Flask, Response, jsonify
 from flask.typing import ResponseReturnValue

--- a/tests/server_stubs/model_upload_stub.py
+++ b/tests/server_stubs/model_upload_stub.py
@@ -1,6 +1,5 @@
 import threading
 from dataclasses import dataclass, field
-from typing import List
 
 from flask import Flask, jsonify, request
 from flask.typing import ResponseReturnValue
@@ -15,7 +14,7 @@ ALLOWED_LICENSE_VALUES = APACHE_LICENSE
 
 @dataclass
 class SharedData:
-    files: List[str] = field(default_factory=list)
+    files: list[str] = field(default_factory=list)
     simulate_308: bool = False
     blob_request_count: int = 0
 

--- a/tests/test_http_dataset_download.py
+++ b/tests/test_http_dataset_download.py
@@ -1,6 +1,6 @@
 import os
 import zipfile
-from typing import List, Optional
+from typing import Optional
 
 import kagglehub
 from kagglehub.cache import DATASETS_CACHE_SUBFOLDER, get_cached_archive_path
@@ -44,7 +44,7 @@ class TestHttpDatasetDownload(BaseTestCase):
         d: str,
         dataset_handle: str,
         expected_subdir_or_subpath: str,
-        expected_files: Optional[List[str]] = None,
+        expected_files: Optional[list[str]] = None,
         **kwargs,  # noqa: ANN003
     ) -> None:
         # Download the full datasets and ensure all files are there.

--- a/tests/test_http_model_download.py
+++ b/tests/test_http_model_download.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Optional
+from typing import Optional
 
 import requests
 
@@ -44,7 +44,7 @@ class TestHttpModelDownload(BaseTestCase):
         d: str,
         model_handle: str,
         expected_subdir_or_subpath: str,
-        expected_files: Optional[List[str]] = None,
+        expected_files: Optional[list[str]] = None,
         **kwargs,  # noqa: ANN003
     ) -> None:
         # Download the full model and ensure all files are there.

--- a/tests/test_kaggle_api_client.py
+++ b/tests/test_kaggle_api_client.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch
 
@@ -10,13 +9,6 @@ from tests.fixtures import BaseTestCase
 
 from .server_stubs import kaggle_api_stub as stub
 from .server_stubs import serv
-
-
-def _patch_metadata_version():  # noqa: ANN202
-    if sys.version_info >= (3, 8):
-        return patch("importlib.metadata.version")
-    else:
-        return patch("importlib_metadata.version")
 
 
 class TestKaggleApiV1Client(BaseTestCase):
@@ -94,7 +86,7 @@ class TestKaggleApiV1Client(BaseTestCase):
     def test_get_user_agent_colab(self) -> None:
         self.assertEqual(clients.get_user_agent(), "kagglehub/0.2.9 colab/release-colab-20230531-060125-RC00-unmanaged")
 
-    @_patch_metadata_version()
+    @patch("importlib.metadata.version")
     @patch("inspect.ismodule")
     @patch("inspect.stack")
     def test_get_user_agent_keras_nlp(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,8 @@
 import os
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Generator, Tuple
 from unittest import mock
 
 from kagglehub.config import CACHE_FOLDER_ENV_VAR_NAME
@@ -13,7 +13,7 @@ def get_test_file_path(relative_path: str) -> str:
     return os.path.join(Path(__file__).parent, "data", relative_path)
 
 
-def resolve_endpoint(var_name: str = "KAGGLE_API_ENDPOINT") -> Tuple[str, int]:
+def resolve_endpoint(var_name: str = "KAGGLE_API_ENDPOINT") -> tuple[str, int]:
     endpoint = os.environ.get(var_name, "127.0.0.1:7777")
     address, port = endpoint.replace("http://", "").split(":")
     return address, int(port)


### PR DESCRIPTION
As a follow up of https://github.com/Kaggle/kagglehub/pull/153, where we deprecated supports for Python 3.7/3.8.

Tested:
- `hatch run lint:all` for Python 3.8+
- `hatch test --all`
- `hatch test integration_tests`
- `./docker_hatch run lint:all` for Python 3.8+