### PR TITLE
Prepare for 0.3.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Next (Unreleased)
 
+## v.0.3.0 (September 4th, 2024)
+
+* Integrate Keras metrics ([#152](https://github.com/Kaggle/kagglehub/pull/152))
+* Enhance logging messages ([#151](https://github.com/Kaggle/kagglehub/pull/151))
+* Upgrade Python version support to 3.9 and above ([#154](https://github.com/Kaggle/kagglehub/pull/154))
+
 ## v.0.2.9 (July 31st, 2024)
 
 * Improve upload by ignoring patterns ([#147](https://github.com/Kaggle/kagglehub/pull/147))

--- a/src/kagglehub/__init__.py
+++ b/src/kagglehub/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.9"
+__version__ = "0.3.0"
 
 import kagglehub.logger  # configures the library logger.
 from kagglehub import colab_cache_resolver, http_resolver, kaggle_cache_resolver, registry

--- a/tests/test_kaggle_api_client.py
+++ b/tests/test_kaggle_api_client.py
@@ -9,6 +9,7 @@ from tests.fixtures import BaseTestCase
 
 from .server_stubs import kaggle_api_stub as stub
 from .server_stubs import serv
+import kagglehub
 
 
 class TestKaggleApiV1Client(BaseTestCase):
@@ -69,13 +70,13 @@ class TestKaggleApiV1Client(BaseTestCase):
 
     @patch.dict("os.environ", {})
     def test_get_user_agent(self) -> None:
-        self.assertEqual(clients.get_user_agent(), "kagglehub/0.2.9")
+        self.assertEqual(clients.get_user_agent(), f"kagglehub/{kagglehub.__version__}")
 
     @patch.dict(
         "os.environ", {"KAGGLE_KERNEL_RUN_TYPE": "Interactive", "KAGGLE_DATA_PROXY_URL": "https://dp.kaggle.net"}
     )
     def test_get_user_agent_kkb(self) -> None:
-        self.assertEqual(clients.get_user_agent(), "kagglehub/0.2.9 kkb/unknown")
+        self.assertEqual(clients.get_user_agent(), f"kagglehub/{kagglehub.__version__} kkb/unknown")
 
     @patch.dict(
         "os.environ",
@@ -84,7 +85,7 @@ class TestKaggleApiV1Client(BaseTestCase):
         },
     )
     def test_get_user_agent_colab(self) -> None:
-        self.assertEqual(clients.get_user_agent(), "kagglehub/0.2.9 colab/release-colab-20230531-060125-RC00-unmanaged")
+        self.assertEqual(clients.get_user_agent(), f"kagglehub/{kagglehub.__version__} colab/release-colab-20230531-060125-RC00-unmanaged")
 
     @patch("importlib.metadata.version")
     @patch("inspect.ismodule")
@@ -102,4 +103,4 @@ class TestKaggleApiV1Client(BaseTestCase):
         ]
         mock_is_module.return_value = True
         mock_version.return_value = "0.15.0"
-        self.assertEqual(clients.get_user_agent(), "kagglehub/0.2.9 keras_nlp/0.15.0")
+        self.assertEqual(clients.get_user_agent(), f"kagglehub/{kagglehub.__version__} keras_nlp/0.15.0")

--- a/tests/test_kaggle_api_client.py
+++ b/tests/test_kaggle_api_client.py
@@ -2,6 +2,7 @@ import os
 from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch
 
+import kagglehub
 from kagglehub import clients
 from kagglehub.clients import KaggleApiV1Client
 from kagglehub.exceptions import DataCorruptionError
@@ -9,7 +10,6 @@ from tests.fixtures import BaseTestCase
 
 from .server_stubs import kaggle_api_stub as stub
 from .server_stubs import serv
-import kagglehub
 
 
 class TestKaggleApiV1Client(BaseTestCase):
@@ -85,7 +85,10 @@ class TestKaggleApiV1Client(BaseTestCase):
         },
     )
     def test_get_user_agent_colab(self) -> None:
-        self.assertEqual(clients.get_user_agent(), f"kagglehub/{kagglehub.__version__} colab/release-colab-20230531-060125-RC00-unmanaged")
+        self.assertEqual(
+            clients.get_user_agent(),
+            f"kagglehub/{kagglehub.__version__} colab/release-colab-20230531-060125-RC00-unmanaged",
+        )
 
     @patch("importlib.metadata.version")
     @patch("inspect.ismodule")

--- a/tools/release/cloudbuild.yaml
+++ b/tools/release/cloudbuild.yaml
@@ -68,7 +68,6 @@ steps:
   id: tests
   dir: $_GITHUB_REPOSITORY
   args:
-  - run
   - test
 
 - name: us-docker.pkg.dev/$PROJECT_ID/tools/hatch:${_PYTHON_VERSION}


### PR DESCRIPTION
New release to enable Keras metrics integration.
Also fixed hardcoded version in test code.

FIX=b/361112861