### PR TITLE
[RFC] Enable authorization via Colab secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Alternatively, you can set the `KAGGLE_CONFIG_DIR` environment variable to chang
 
 Note for Windows users: The default directory is `%HOMEPATH%/kaggle.json`.
 
+#### Option 4: Read credentials from Google Colab secrets
+
+Store your username and key token as Colab secrets `KAGGLE_USERNAME` and `KAGGLE_KEY`.
+
+Instructions on adding secrets in both Colab and Colab Enterprise can be found in [this article](https://www.googlecloudcommunity.com/gc/Cloud-Hub/How-do-I-add-secrets-in-Google-Colab-Enterprise/m-p/784866).
+
 ### Download Model
 
 The following examples download the `answer-equivalence-bem` variation of this Kaggle model: https://www.kaggle.com/models/google/bert/tensorFlow2/answer-equivalence-bem

--- a/src/kagglehub/clients.py
+++ b/src/kagglehub/clients.py
@@ -184,7 +184,7 @@ class KaggleApiV1Client:
         elif is_in_kaggle_notebook():
             return KaggleTokenAuth()
         elif is_in_colab_notebook() and (colab_secret := get_colab_credentials()) is not None:
-            return HTTPBasicAuth(colab_secret[0], colab_secret[1])
+            return HTTPBasicAuth(colab_secret.username, colab_secret.key)
         return None
 
     def _build_url(self, path: str) -> str:
@@ -313,7 +313,7 @@ class ColabClient:
         elif is_in_kaggle_notebook():
             return KaggleTokenAuth()
         elif is_in_colab_notebook() and (colab_secret := get_colab_credentials()) is not None:
-            return HTTPBasicAuth(colab_secret[0], colab_secret[1])
+            return HTTPBasicAuth(colab_secret.username, colab_secret.key)
         return None
 
 

--- a/src/kagglehub/config.py
+++ b/src/kagglehub/config.py
@@ -150,6 +150,7 @@ def clear_kaggle_credentials() -> None:
 
 
 def get_colab_credentials() -> Optional[tuple[str, str]]:
+    # userdata access is already thread-safe after b/318732641
     try:
         from google.colab import userdata  # type: ignore[import]
         from google.colab.errors import Error as ColabError  # type: ignore[import]

--- a/src/kagglehub/config.py
+++ b/src/kagglehub/config.py
@@ -30,6 +30,9 @@ TBE_RUNTIME_ADDR_ENV_VAR_NAME = "TBE_RUNTIME_ADDR"
 CREDENTIALS_JSON_USERNAME = "username"
 CREDENTIALS_JSON_KEY = "key"
 
+COLAB_SECRET_USERNAME = "KAGGLE_USERNAME"
+COLAB_SECRET_KEY = "KAGGLE_KEY"
+
 _kaggle_credentials = None
 
 LOG_LEVELS_MAP = {
@@ -144,3 +147,23 @@ def set_kaggle_credentials(username: str, api_key: str) -> None:
 def clear_kaggle_credentials() -> None:
     global _kaggle_credentials  # noqa: PLW0603
     _kaggle_credentials = None
+
+
+def get_colab_credentials() -> Optional[tuple[str, str]]:
+    try:
+        from google.colab import userdata  # type: ignore[import]
+        from google.colab.errors import Error as ColabError  # type: ignore[import]
+    except ImportError:
+        return None
+
+    try:
+        username = userdata.get(COLAB_SECRET_USERNAME)
+        key = userdata.get(COLAB_SECRET_KEY)
+        return (username, key)
+    except userdata.NotebookAccessError:
+        logger.warning("Access to secret %s and %s are not granted.", COLAB_SECRET_USERNAME, COLAB_SECRET_KEY)
+    except userdata.SecretNotFoundError:
+        logger.warning("Access to secret %s and %s are not defined.", COLAB_SECRET_USERNAME, COLAB_SECRET_KEY)
+    except ColabError:
+        logger.warning("Error fetching secret %s and %s", COLAB_SECRET_USERNAME, COLAB_SECRET_KEY)
+    return None


### PR DESCRIPTION
Provide authorization via colab secrets for `colab_cache_resolver` (`ColabClient`) and `http_resolver` (`KaggleApiV1Client`)


FIX=b/361069956
TESTED=[Colab notebook](http://go/colabx-drive/1v85aic1hkLHQErWcayR4LHidTAcBwRS5)