### PR TITLE
Add Competition Download method pt 1

### DIFF
--- a/integration_tests/test_competition_download.py
+++ b/integration_tests/test_competition_download.py
@@ -1,0 +1,53 @@
+import unittest
+
+from requests import HTTPError
+
+from kagglehub import competition_download
+
+from .utils import assert_files, create_test_cache
+
+HANDLE = "titanic"
+
+
+class TestCompetitionDownload(unittest.TestCase):
+    def test_competition_succeeds(self) -> None:
+        with create_test_cache():
+            expected_files = [
+                "gender_submission.csv",
+                "test.csv",
+                "train.csv",
+            ]
+
+            actual_path = competition_download(HANDLE)
+
+            assert_files(self, actual_path, expected_files)
+
+    def test_competition_login_needed_succeeds(self) -> None:
+        with create_test_cache():
+            expected_files = [
+                "sample_submission.csv",
+                "test_identity.csv",
+                "test_transaction.csv",
+                "train_identity.csv",
+                "train_transaction.csv",
+            ]
+
+            actual_path = competition_download("ieee-fraud-detection")
+
+            assert_files(self, actual_path, expected_files)
+
+    def test_competition_multiple_files(self) -> None:
+        with create_test_cache():
+            file_paths = [
+                "gender_submission.csv",
+                "test.csv",
+                "train.csv",
+            ]
+            for p in file_paths:
+                actual_path = competition_download(HANDLE, path=p)
+                assert_files(self, actual_path, [p])
+
+    def test_competition_with_incorrect_file_path(self) -> None:
+        incorrect_path = "nonxisten/Test"
+        with self.assertRaises(HTTPError):
+            competition_download(HANDLE, path=incorrect_path)

--- a/integration_tests/test_competition_download.py
+++ b/integration_tests/test_competition_download.py
@@ -22,7 +22,7 @@ class TestCompetitionDownload(unittest.TestCase):
 
             assert_files(self, actual_path, expected_files)
 
-    def test_competition_login_needed_succeeds(self) -> None:
+    def test_competition_competition_rules_accepted_succeeds(self) -> None:
         with create_test_cache():
             expected_files = [
                 "sample_submission.csv",
@@ -35,6 +35,12 @@ class TestCompetitionDownload(unittest.TestCase):
             actual_path = competition_download("ieee-fraud-detection")
 
             assert_files(self, actual_path, expected_files)
+
+    def test_competition_competition_rules_not_accepted_fails(self) -> None:
+        # integrationtester bot has not accepted competiton rules
+        with self.assertRaises(HTTPError) as e:
+            competition_download("jane-street-market-prediction")
+            self.assertEqual(e.exception.errno, 403)
 
     def test_competition_multiple_files(self) -> None:
         with create_test_cache():
@@ -49,5 +55,6 @@ class TestCompetitionDownload(unittest.TestCase):
 
     def test_competition_with_incorrect_file_path(self) -> None:
         incorrect_path = "nonxisten/Test"
-        with self.assertRaises(HTTPError):
+        with self.assertRaises(HTTPError) as e:
             competition_download(HANDLE, path=incorrect_path)
+            self.assertEqual(e.exception.errno, 403)

--- a/src/kagglehub/__init__.py
+++ b/src/kagglehub/__init__.py
@@ -3,9 +3,9 @@ __version__ = "0.3.0"
 import kagglehub.logger  # configures the library logger.
 from kagglehub import colab_cache_resolver, http_resolver, kaggle_cache_resolver, registry
 from kagglehub.auth import login, whoami
+from kagglehub.competition import competition_download
 from kagglehub.datasets import dataset_download, dataset_upload
 from kagglehub.models import model_download, model_upload
-from kagglehub.competition import competition_download
 
 registry.model_resolver.add_implementation(http_resolver.ModelHttpResolver())
 registry.model_resolver.add_implementation(kaggle_cache_resolver.ModelKaggleCacheResolver())

--- a/src/kagglehub/__init__.py
+++ b/src/kagglehub/__init__.py
@@ -5,6 +5,7 @@ from kagglehub import colab_cache_resolver, http_resolver, kaggle_cache_resolver
 from kagglehub.auth import login, whoami
 from kagglehub.datasets import dataset_download, dataset_upload
 from kagglehub.models import model_download, model_upload
+from kagglehub.competition import competition_download
 
 registry.model_resolver.add_implementation(http_resolver.ModelHttpResolver())
 registry.model_resolver.add_implementation(kaggle_cache_resolver.ModelKaggleCacheResolver())
@@ -12,3 +13,5 @@ registry.model_resolver.add_implementation(colab_cache_resolver.ModelColabCacheR
 
 registry.dataset_resolver.add_implementation(http_resolver.DatasetHttpResolver())
 registry.dataset_resolver.add_implementation(kaggle_cache_resolver.DatasetKaggleCacheResolver())
+
+registry.competition_resolver.add_implementation(http_resolver.CompetitionHttpResolver())

--- a/src/kagglehub/cache.py
+++ b/src/kagglehub/cache.py
@@ -8,7 +8,6 @@ from kagglehub.handle import CompetitionHandle, DatasetHandle, ModelHandle, Reso
 
 DATASETS_CACHE_SUBFOLDER = "datasets"
 COMPETITIONS_CACHE_SUBFOLDER = "competitions"
-COMPETITIONS_INDIVIDUAL_FILE_MARKER_FOLDER = ".competition-individual-file-markers"
 MODELS_CACHE_SUBFOLDER = "models"
 FILE_COMPLETION_MARKER_FOLDER = ".complete"
 
@@ -219,7 +218,7 @@ def _get_competitions_completion_marker_filepath(handle: CompetitionHandle, path
         return os.path.join(
             get_cache_folder(),
             COMPETITIONS_CACHE_SUBFOLDER,
-            COMPETITIONS_INDIVIDUAL_FILE_MARKER_FOLDER,
+            FILE_COMPLETION_MARKER_FOLDER,
             f"{handle.competition}",
             f"{path}.complete",
         )

--- a/src/kagglehub/cache.py
+++ b/src/kagglehub/cache.py
@@ -8,7 +8,7 @@ from kagglehub.handle import CompetitionHandle, DatasetHandle, ModelHandle, Reso
 
 DATASETS_CACHE_SUBFOLDER = "datasets"
 COMPETITIONS_CACHE_SUBFOLDER = "competitions"
-COMPETITIONS_INDIVIDUAL_FILE_MARKER_FOLDER = ".competition-indivial-file-markers"
+COMPETITIONS_INDIVIDUAL_FILE_MARKER_FOLDER = ".competition-individual-file-markers"
 MODELS_CACHE_SUBFOLDER = "models"
 FILE_COMPLETION_MARKER_FOLDER = ".complete"
 

--- a/src/kagglehub/cache.py
+++ b/src/kagglehub/cache.py
@@ -4,9 +4,10 @@ from pathlib import Path
 from typing import Optional
 
 from kagglehub.config import get_cache_folder
-from kagglehub.handle import DatasetHandle, ModelHandle, ResourceHandle
+from kagglehub.handle import DatasetHandle, ModelHandle, CompetitionHandle, ResourceHandle
 
 DATASETS_CACHE_SUBFOLDER = "datasets"
+COMPETITIONS_CACHE_SUBFOLDER = "datasets"
 MODELS_CACHE_SUBFOLDER = "models"
 FILE_COMPLETION_MARKER_FOLDER = ".complete"
 
@@ -32,6 +33,8 @@ def get_cached_path(handle: ResourceHandle, path: Optional[str] = None) -> str:
         return _get_model_path(handle, path)
     elif isinstance(handle, DatasetHandle):
         return _get_dataset_path(handle, path)
+    elif isinstance(handle, CompetitionHandle):
+        return _get_competition_path(handle, path)
     else:
         msg = "Invalid handle"
         raise ValueError(msg)
@@ -108,6 +111,10 @@ def _get_dataset_path(handle: DatasetHandle, path: Optional[str] = None) -> str:
     if handle.is_versioned():
         base_path = os.path.join(base_path, "versions", str(handle.version))
 
+    return os.path.join(base_path, path) if path else base_path
+
+def _get_competition_path(handle: CompetitionHandle, path: Optional[str] = None) -> str:
+    base_path = os.path.join(get_cache_folder(), COMPETITIONS_CACHE_SUBFOLDER, handle.competition)
     return os.path.join(base_path, path) if path else base_path
 
 

--- a/src/kagglehub/cache.py
+++ b/src/kagglehub/cache.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Optional
 
 from kagglehub.config import get_cache_folder
-from kagglehub.handle import DatasetHandle, ModelHandle, CompetitionHandle, ResourceHandle
+from kagglehub.handle import CompetitionHandle, DatasetHandle, ModelHandle, ResourceHandle
 
 DATASETS_CACHE_SUBFOLDER = "datasets"
 COMPETITIONS_CACHE_SUBFOLDER = "competitions"
@@ -117,6 +117,7 @@ def _get_dataset_path(handle: DatasetHandle, path: Optional[str] = None) -> str:
 
     return os.path.join(base_path, path) if path else base_path
 
+
 def _get_competition_path(handle: CompetitionHandle, path: Optional[str] = None) -> str:
     base_path = os.path.join(get_cache_folder(), COMPETITIONS_CACHE_SUBFOLDER, handle.competition)
     return os.path.join(base_path, path) if path else base_path
@@ -157,12 +158,14 @@ def _get_dataset_archive_path(handle: DatasetHandle) -> str:
         f"{handle.version!s}.archive",
     )
 
+
 def _get_competition_archive_path(handle: CompetitionHandle) -> str:
     return os.path.join(
         get_cache_folder(),
         COMPETITIONS_CACHE_SUBFOLDER,
         f"{handle.competition}.archive",
     )
+
 
 def _get_models_completion_marker_filepath(handle: ModelHandle, path: Optional[str] = None) -> str:
     if path:
@@ -208,6 +211,7 @@ def _get_datasets_completion_marker_filepath(handle: DatasetHandle, path: Option
         handle.dataset,
         f"{handle.version!s}.complete",
     )
+
 
 def _get_competitions_completion_marker_filepath(handle: CompetitionHandle, path: Optional[str] = None) -> str:
     if path:

--- a/src/kagglehub/cache.py
+++ b/src/kagglehub/cache.py
@@ -7,7 +7,7 @@ from kagglehub.config import get_cache_folder
 from kagglehub.handle import DatasetHandle, ModelHandle, CompetitionHandle, ResourceHandle
 
 DATASETS_CACHE_SUBFOLDER = "datasets"
-COMPETITIONS_CACHE_SUBFOLDER = "datasets"
+COMPETITIONS_CACHE_SUBFOLDER = "competitions"
 MODELS_CACHE_SUBFOLDER = "models"
 FILE_COMPLETION_MARKER_FOLDER = ".complete"
 
@@ -45,6 +45,8 @@ def get_cached_archive_path(handle: ResourceHandle) -> str:
         return _get_model_archive_path(handle)
     elif isinstance(handle, DatasetHandle):
         return _get_dataset_archive_path(handle)
+    elif isinstance(handle, CompetitionHandle):
+        return _get_competition_archive_path(handle)
     else:
         msg = "Invalid handle"
         raise ValueError(msg)
@@ -101,6 +103,8 @@ def _get_completion_marker_filepath(handle: ResourceHandle, path: Optional[str] 
         return _get_models_completion_marker_filepath(handle, path)
     elif isinstance(handle, DatasetHandle):
         return _get_datasets_completion_marker_filepath(handle, path)
+    elif isinstance(handle, CompetitionHandle):
+        return _get_competitions_completion_marker_filepath(handle, path)
     else:
         msg = "Invalid handle"
         raise ValueError(msg)
@@ -153,6 +157,12 @@ def _get_dataset_archive_path(handle: DatasetHandle) -> str:
         f"{handle.version!s}.archive",
     )
 
+def _get_competition_archive_path(handle: CompetitionHandle) -> str:
+    return os.path.join(
+        get_cache_folder(),
+        COMPETITIONS_CACHE_SUBFOLDER,
+        f"{handle.competition}.archive",
+    )
 
 def _get_models_completion_marker_filepath(handle: ModelHandle, path: Optional[str] = None) -> str:
     if path:
@@ -197,4 +207,20 @@ def _get_datasets_completion_marker_filepath(handle: DatasetHandle, path: Option
         handle.owner,
         handle.dataset,
         f"{handle.version!s}.complete",
+    )
+
+def _get_competitions_completion_marker_filepath(handle: CompetitionHandle, path: Optional[str] = None) -> str:
+    if path:
+        return os.path.join(
+            get_cache_folder(),
+            COMPETITIONS_CACHE_SUBFOLDER,
+            handle.competition,
+            FILE_COMPLETION_MARKER_FOLDER,
+            f"{path}.complete",
+        )
+
+    return os.path.join(
+        get_cache_folder(),
+        COMPETITIONS_CACHE_SUBFOLDER,
+        f"{handle.competition}.complete",
     )

--- a/src/kagglehub/cache.py
+++ b/src/kagglehub/cache.py
@@ -8,6 +8,7 @@ from kagglehub.handle import CompetitionHandle, DatasetHandle, ModelHandle, Reso
 
 DATASETS_CACHE_SUBFOLDER = "datasets"
 COMPETITIONS_CACHE_SUBFOLDER = "competitions"
+COMPETITIONS_INDIVIDUAL_FILE_MARKER_FOLDER = ".competition-indivial-file-markers"
 MODELS_CACHE_SUBFOLDER = "models"
 FILE_COMPLETION_MARKER_FOLDER = ".complete"
 
@@ -218,8 +219,8 @@ def _get_competitions_completion_marker_filepath(handle: CompetitionHandle, path
         return os.path.join(
             get_cache_folder(),
             COMPETITIONS_CACHE_SUBFOLDER,
-            handle.competition,
-            FILE_COMPLETION_MARKER_FOLDER,
+            COMPETITIONS_INDIVIDUAL_FILE_MARKER_FOLDER,
+            f"{handle.competition}",
             f"{path}.complete",
         )
 

--- a/src/kagglehub/clients.py
+++ b/src/kagglehub/clients.py
@@ -200,7 +200,6 @@ class KaggleApiV1Client:
 
             return True
 
-
     def _get_auth(self) -> Optional[requests.auth.AuthBase]:
         if self.credentials:
             return HTTPBasicAuth(self.credentials.username, self.credentials.key)

--- a/src/kagglehub/clients.py
+++ b/src/kagglehub/clients.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import logging
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urljoin
@@ -13,6 +14,7 @@ from requests.auth import HTTPBasicAuth
 from tqdm import tqdm
 
 import kagglehub
+from kagglehub.cache import delete_from_cache, get_cached_archive_path
 from kagglehub.config import get_colab_credentials, get_kaggle_api_endpoint, get_kaggle_credentials
 from kagglehub.env import (
     KAGGLE_DATA_PROXY_URL_ENV_VAR_NAME,
@@ -33,7 +35,7 @@ from kagglehub.exceptions import (
     kaggle_api_raise_for_status,
     process_post_response,
 )
-from kagglehub.handle import ResourceHandle
+from kagglehub.handle import CompetitionHandle, ResourceHandle
 from kagglehub.integrity import get_md5_checksum_from_response, to_b64_digest, update_hash_from_file
 
 CHUNK_SIZE = 1048576
@@ -130,7 +132,20 @@ class KaggleApiV1Client:
             self._check_for_version_update(response)
             return response_dict
 
-    def download_file(self, path: str, out_file: str, resource_handle: Optional[ResourceHandle] = None) -> None:
+    def download_file(
+        self,
+        path: str,
+        out_file: str,
+        resource_handle: Optional[ResourceHandle] = None,
+        cached_path: Optional[str] = None,
+    ) -> bool:
+        """
+        Issues a call to kaggle api and downloads files. For competition downloads,
+        call may return early if local cache is newer than the last time the file was modified.
+
+        Returns:
+        bool:  If downloading remote was necessary
+        """
         url = self._build_url(path)
         with requests.get(
             url,
@@ -143,6 +158,11 @@ class KaggleApiV1Client:
             total_size = int(response.headers["Content-Length"])
             size_read = 0
 
+            if isinstance(resource_handle, CompetitionHandle) and not _download_needed(
+                response, resource_handle, cached_path
+            ):
+                return False
+
             expected_md5_hash = get_md5_checksum_from_response(response)
             hash_object = hashlib.md5() if expected_md5_hash else None
 
@@ -152,7 +172,7 @@ class KaggleApiV1Client:
 
                 if size_read == total_size:
                     logger.info(f"Download already complete ({size_read} bytes).")
-                    return
+                    return True
 
                 logger.info(f"Resuming download from {size_read} bytes ({total_size - size_read} bytes left)...")
 
@@ -177,6 +197,9 @@ class KaggleApiV1Client:
                     raise DataCorruptionError(
                         _CHECKSUM_MISMATCH_MSG_TEMPLATE.format(expected_md5_hash, actual_md5_hash)
                     )
+
+            return True
+
 
     def _get_auth(self) -> Optional[requests.auth.AuthBase]:
         if self.credentials:
@@ -211,6 +234,52 @@ def _download_file(
                     hash_object.update(chunk)
                 size_read = min(total_size, size_read + CHUNK_SIZE)
                 progress_bar.update(len(chunk))
+
+
+def _download_needed(response: requests.Response, h: ResourceHandle, cached_path: Optional[str] = None) -> bool:
+    """
+    Determine if a download is needed based on timestamp and cached path.
+
+    Returns:
+        bool: download needed.
+    """
+    if not cached_path:
+        return True
+
+    last_modified = response.headers.get("Last-Modified")
+    if last_modified is None:
+        delete_from_cache(h, cached_path)
+
+        archive_path = get_cached_archive_path(h)
+        os.makedirs(os.path.dirname(archive_path), exist_ok=True)
+
+        return True
+    else:
+        remote_date = datetime.strptime(response.headers["Last-Modified"], "%a, %d %b %Y %H:%M:%S %Z").replace(
+            tzinfo=timezone.utc
+        )
+
+    file_exists = os.path.exists(cached_path)
+    if file_exists:
+        local_date = datetime.fromtimestamp(os.path.getmtime(cached_path), tz=timezone.utc)
+
+        download_needed = remote_date >= local_date
+        if download_needed:
+            delete_from_cache(h, cached_path)
+
+            archive_path = get_cached_archive_path(h)
+            os.makedirs(os.path.dirname(archive_path), exist_ok=True)
+
+            return True
+
+        return False
+
+    delete_from_cache(h, cached_path)
+
+    archive_path = get_cached_archive_path(h)
+    os.makedirs(os.path.dirname(archive_path), exist_ok=True)
+
+    return True
 
 
 # These environment variables are set by the Kaggle notebook environment.

--- a/src/kagglehub/competition.py
+++ b/src/kagglehub/competition.py
@@ -12,8 +12,8 @@ def competition_download(handle: str, path: Optional[str] = None, *, force_downl
     """Download competition files
     Args:
         handle: (string) the competition name
-        path: (string) Optional path to a file within a competition
-        force_download: (bool) Optional flag to force download a competition, even if it's cached
+        path: (string) Optional path to a file within a competition dataset
+        force_download: (bool) Optional flag to force download a competition dataset, even if it's cached
     Returns:
         A string requesting the path to the requested competition files.
     """

--- a/src/kagglehub/competition.py
+++ b/src/kagglehub/competition.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 def competition_download(handle: str, path: Optional[str] = None, *, force_download: Optional[bool] = False) -> str:
-    """Download competition files
+    """Download competition dataset
     Args:
         handle: (string) the competition name
         path: (string) Optional path to a file within a competition dataset

--- a/src/kagglehub/competition.py
+++ b/src/kagglehub/competition.py
@@ -20,4 +20,4 @@ def competition_download(handle: str, path: Optional[str] = None, *, force_downl
 
     h = parse_dataset_handle(handle)
     logger.info(f"Downloading competition: {h.to_url()} ...", extra={**EXTRA_CONSOLE_BLOCK})
-    return registry.dataset_resolver(h, path, force_download=force_download)
+    return registry.competition_resolver(h, path, force_download=force_download)

--- a/src/kagglehub/competition.py
+++ b/src/kagglehub/competition.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional
 
 from kagglehub import registry
-from kagglehub.handle import parse_dataset_handle
+from kagglehub.handle import parse_competition_handle
 from kagglehub.logger import EXTRA_CONSOLE_BLOCK
 
 logger = logging.getLogger(__name__)
@@ -18,6 +18,6 @@ def competition_download(handle: str, path: Optional[str] = None, *, force_downl
         A string requesting the path to the requested competition files.
     """
 
-    h = parse_dataset_handle(handle)
+    h = parse_competition_handle(handle)
     logger.info(f"Downloading competition: {h.to_url()} ...", extra={**EXTRA_CONSOLE_BLOCK})
     return registry.competition_resolver(h, path, force_download=force_download)

--- a/src/kagglehub/competition.py
+++ b/src/kagglehub/competition.py
@@ -1,0 +1,23 @@
+import logging
+from typing import Optional
+
+from kagglehub import registry
+from kagglehub.handle import parse_dataset_handle
+from kagglehub.logger import EXTRA_CONSOLE_BLOCK
+
+logger = logging.getLogger(__name__)
+
+
+def competition_download(handle: str, path: Optional[str] = None, *, force_download: Optional[bool] = False) -> str:
+    """Download competition files
+    Args:
+        handle: (string) the competition name
+        path: (string) Optional path to a file within a competition
+        force_download: (bool) Optional flag to force download a competition, even if it's cached
+    Returns:
+        A string requesting the path to the requested competition files.
+    """
+
+    h = parse_dataset_handle(handle)
+    logger.info(f"Downloading competition: {h.to_url()} ...", extra={**EXTRA_CONSOLE_BLOCK})
+    return registry.dataset_resolver(h, path, force_download=force_download)

--- a/src/kagglehub/exceptions.py
+++ b/src/kagglehub/exceptions.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 
 import requests
 
-from kagglehub.handle import ResourceHandle
+from kagglehub.handle import CompetitionHandle, ResourceHandle
 
 
 class CredentialError(Exception):
@@ -59,15 +59,24 @@ def kaggle_api_raise_for_status(response: requests.Response, resource_handle: Op
     except requests.HTTPError as e:
         message = str(e)
         resource_url = resource_handle.to_url() if resource_handle else response.url
-
         if response.status_code in {HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN}:
-            message = (
-                f"{response.status_code} Client Error."
-                "\n\n"
-                f"You don't have permission to access resource at URL: {resource_url}"
-                "\nPlease make sure you are authenticated if you are trying to access a private resource or a resource"
-                " requiring consent."
-            )
+            if isinstance(resource_handle, CompetitionHandle):
+                message = (
+                    f"{response.status_code} Client Error."
+                    "\n\n"
+                    f"You don't have permission to access resource at URL: {resource_url}"
+                    "\nPlease make sure you are authenticated and have accepted the competition rules which"
+                    f" can be found using this at: {resource_url}/rules"
+                )
+            else:
+                message = (
+                    f"{response.status_code} Client Error."
+                    "\n\n"
+                    f"You don't have permission to access resource at URL: {resource_url}"
+                    "\nPlease make sure you are authenticated if you are trying to access a"
+                    " private resource or a resource requiring consent."
+                )
+
         if response.status_code == HTTPStatus.NOT_FOUND:
             message = (
                 f"{response.status_code} Client Error."

--- a/src/kagglehub/exceptions.py
+++ b/src/kagglehub/exceptions.py
@@ -66,7 +66,7 @@ def kaggle_api_raise_for_status(response: requests.Response, resource_handle: Op
                     "\n\n"
                     f"You don't have permission to access resource at URL: {resource_url}"
                     "\nPlease make sure you are authenticated and have accepted the competition rules which"
-                    f" can be found using this at: {resource_url}/rules"
+                    f" can be found at this location: {resource_url}/rules"
                 )
             else:
                 message = (

--- a/src/kagglehub/handle.py
+++ b/src/kagglehub/handle.py
@@ -15,8 +15,6 @@ NUM_UNVERSIONED_MODEL_PARTS = 4  # e.g.: <owner>/<model>/<framework>/<variation>
 
 @dataclass
 class ResourceHandle:
-    owner: str
-
     @abc.abstractmethod
     def to_url(self) -> str:
         """Returns URL to the resource detail page."""
@@ -25,6 +23,7 @@ class ResourceHandle:
 
 @dataclass
 class ModelHandle(ResourceHandle):
+    owner: str
     model: str
     framework: str
     variation: str
@@ -75,7 +74,7 @@ class CompetitionHandle(ResourceHandle):
     competition: str
 
     def __str__(self) -> str:
-        handle_str = f"competitions/{self.competition}"
+        handle_str = f"{self.competition}"
         return handle_str
 
     def to_url(self) -> str:
@@ -148,10 +147,8 @@ def parse_model_handle(handle: str) -> ModelHandle:
 
 
 def parse_competition_handle(handle: str) -> CompetitionHandle:
-    parts = handle.split("/")
+    if "/" in handle:
+        msg = f"Invalid competition handle: {handle}"
+        raise ValueError(msg)
 
-    if len(parts) == 1:
-        return CompetitionHandle(owner="", competition=parts[0])
-
-    msg = f"Invalid competition handle: {handle}"
-    raise ValueError(msg)
+    return CompetitionHandle(competition=handle)

--- a/src/kagglehub/handle.py
+++ b/src/kagglehub/handle.py
@@ -149,7 +149,7 @@ def parse_competition_handle(handle: str) -> DatasetHandle:
     parts = handle.split("/")
 
     if len(parts) == 1:
-        return CompetitionHandle(competition=parts[0])
+        return CompetitionHandle(owner="", competition=parts[0])
 
     msg = f"Invalid competition handle: {handle}"
     raise ValueError(msg)

--- a/src/kagglehub/handle.py
+++ b/src/kagglehub/handle.py
@@ -145,7 +145,7 @@ def parse_model_handle(handle: str) -> ModelHandle:
     msg = f"Invalid model handle: {handle}"
     raise ValueError(msg)
 
-def parse_competition_handle(handle: str) -> DatasetHandle:
+def parse_competition_handle(handle: str) -> CompetitionHandle:
     parts = handle.split("/")
 
     if len(parts) == 1:

--- a/src/kagglehub/handle.py
+++ b/src/kagglehub/handle.py
@@ -69,6 +69,7 @@ class DatasetHandle(ResourceHandle):
             return f"{base_url}/versions/{self.version}"
         return base_url
 
+
 @dataclass
 class CompetitionHandle(ResourceHandle):
     competition: str
@@ -144,6 +145,7 @@ def parse_model_handle(handle: str) -> ModelHandle:
 
     msg = f"Invalid model handle: {handle}"
     raise ValueError(msg)
+
 
 def parse_competition_handle(handle: str) -> CompetitionHandle:
     parts = handle.split("/")

--- a/src/kagglehub/handle.py
+++ b/src/kagglehub/handle.py
@@ -12,8 +12,6 @@ NUM_UNVERSIONED_DATASET_PARTS = 2  # e.g.: <owner>/<dataset>
 NUM_VERSIONED_MODEL_PARTS = 5  # e.g.: <owner>/<model>/<framework>/<variation>/<version>
 NUM_UNVERSIONED_MODEL_PARTS = 4  # e.g.: <owner>/<model>/<framework>/<variation>
 
-# TODO(b/313706281): Implement a DatasetHandle class & parse_dataset_handle method.
-
 
 @dataclass
 class ResourceHandle:
@@ -69,6 +67,19 @@ class DatasetHandle(ResourceHandle):
         base_url = f"{endpoint}/datasets/{self.owner}/{self.dataset}"
         if self.is_versioned():
             return f"{base_url}/versions/{self.version}"
+        return base_url
+
+@dataclass
+class CompetitionHandle(ResourceHandle):
+    competition: str
+
+    def __str__(self) -> str:
+        handle_str = f"competitions/{self.competition}"
+        return handle_str
+
+    def to_url(self) -> str:
+        endpoint = get_kaggle_api_endpoint()
+        base_url = f"{endpoint}/competitions/{self.competition}"
         return base_url
 
 
@@ -132,4 +143,13 @@ def parse_model_handle(handle: str) -> ModelHandle:
         )
 
     msg = f"Invalid model handle: {handle}"
+    raise ValueError(msg)
+
+def parse_competition_handle(handle: str) -> DatasetHandle:
+    parts = handle.split("/")
+
+    if len(parts) == 1:
+        return CompetitionHandle(competition=parts[0])
+
+    msg = f"Invalid competition handle: {handle}"
     raise ValueError(msg)

--- a/src/kagglehub/http_resolver.py
+++ b/src/kagglehub/http_resolver.py
@@ -64,7 +64,7 @@ class CompetitionHttpResolver(Resolver[CompetitionHandle]):
                     return cached_path
                 raise
 
-            if not download_needed:
+            if not download_needed and cached_path:
                 return cached_path
         else:
             # Download, extract, then delete the archive.
@@ -81,7 +81,7 @@ class CompetitionHttpResolver(Resolver[CompetitionHandle]):
                     return cached_path
                 raise
 
-            if not download_needed:
+            if not download_needed and cached_path:
                 if os.path.exists(archive_path):
                     os.remove(archive_path)
                 return cached_path

--- a/src/kagglehub/http_resolver.py
+++ b/src/kagglehub/http_resolver.py
@@ -14,7 +14,7 @@ from kagglehub.cache import (
     mark_as_complete,
 )
 from kagglehub.clients import KaggleApiV1Client
-from kagglehub.handle import DatasetHandle, ModelHandle, CompetitionHandle, ResourceHandle
+from kagglehub.handle import CompetitionHandle, DatasetHandle, ModelHandle, ResourceHandle
 from kagglehub.resolver import Resolver
 
 DATASET_CURRENT_VERSION_FIELD = "currentVersionNumber"
@@ -30,7 +30,9 @@ class CompetitionHttpResolver(Resolver[CompetitionHandle]):
         # Downloading files over HTTP is supported in all environments for all handles / paths.
         return True
 
-    def __call__(self, h: CompetitionHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False) -> str:
+    def __call__(
+        self, h: CompetitionHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False
+    ) -> str:
         api_client = KaggleApiV1Client()
 
         cached_path = load_from_cache(h, path)
@@ -244,6 +246,7 @@ def _build_dataset_download_url_path(h: DatasetHandle) -> str:
 
 def _build_competition_download_all_url_path(h: CompetitionHandle) -> str:
     return f"competitions/data/download-all/{h.competition}"
+
 
 def _build_competition_download_file_path(h: CompetitionHandle, file: str) -> str:
     return f"competitions/data/download/{h.competition}/{file}"

--- a/src/kagglehub/http_resolver.py
+++ b/src/kagglehub/http_resolver.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from tqdm.contrib.concurrent import thread_map
 
+from kagglehub.auth import whoami
 from kagglehub.cache import (
     delete_from_cache,
     get_cached_archive_path,
@@ -33,6 +34,9 @@ class CompetitionHttpResolver(Resolver[CompetitionHandle]):
     def __call__(
         self, h: CompetitionHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False
     ) -> str:
+        # competition does not alllow for anonymous download
+        _ = whoami()
+
         api_client = KaggleApiV1Client()
 
         cached_path = load_from_cache(h, path)

--- a/src/kagglehub/http_resolver.py
+++ b/src/kagglehub/http_resolver.py
@@ -248,7 +248,7 @@ class ModelHttpResolver(Resolver[ModelHandle]):
 
 
 def _extract_archive(archive_path: str, out_path: str) -> None:
-    logger.info("Extracting model files...")
+    logger.info("Extracting files...")
     if tarfile.is_tarfile(archive_path):
         with tarfile.open(archive_path) as f:
             f.extractall(out_path)
@@ -319,4 +319,4 @@ def _build_dataset_download_url_path(h: DatasetHandle) -> str:
 
 
 def _build_competition_download_url_path(h: CompetitionHandle) -> str:
-    return f"/competitions/data/download/{h.competition}"
+    return f"competitions/data/download-all/{h.competition}"

--- a/src/kagglehub/registry.py
+++ b/src/kagglehub/registry.py
@@ -30,3 +30,5 @@ class MultiImplRegistry:
 
 model_resolver = MultiImplRegistry("ModelResolver")
 dataset_resolver = MultiImplRegistry("DatasetResolver")
+competition_resolver = MultiImplRegistry("CompetitionResolver")
+

--- a/src/kagglehub/registry.py
+++ b/src/kagglehub/registry.py
@@ -31,4 +31,3 @@ class MultiImplRegistry:
 model_resolver = MultiImplRegistry("ModelResolver")
 dataset_resolver = MultiImplRegistry("DatasetResolver")
 competition_resolver = MultiImplRegistry("CompetitionResolver")
-

--- a/tests/server_stubs/competition_download_stub.py
+++ b/tests/server_stubs/competition_download_stub.py
@@ -11,10 +11,12 @@ from tests.utils import get_test_file_path
 
 app = Flask(__name__)
 
-TARGZ_ARCHIVE_HANDLE = "king-of the-targz"
+TARGZ_ARCHIVE_HANDLE = "competition-targz"
 
 # See https://cloud.google.com/storage/docs/xml-api/reference-headers#xgooghash
 GCS_HASH_HEADER = "x-goog-hash"
+LAST_MODIFIED = "Last-Modified"
+LAST_MODIFIED_DATE = "Thu, 02 Mar 2020 02:17:12 GMT"
 
 
 @app.route("/", methods=["HEAD"])
@@ -39,6 +41,7 @@ def competition_download(competition_slug: str) -> ResponseReturnValue:
         file_hash.update(content)
         resp = Response()
         resp.headers[GCS_HASH_HEADER] = f"md5={to_b64_digest(file_hash)}"
+        resp.headers[LAST_MODIFIED] = LAST_MODIFIED_DATE
         resp.content_type = content_type
         resp.content_length = os.path.getsize(test_file_path)
         resp.data = content
@@ -65,7 +68,11 @@ def competition_download_file(competition_slug: str, file_name: str) -> Response
         return (
             Response(
                 generate_file_content(),
-                headers={GCS_HASH_HEADER: f"md5={to_b64_digest(file_hash)}", "Content-Length": str(len(content))},
+                headers={
+                    GCS_HASH_HEADER: f"md5={to_b64_digest(file_hash)}",
+                    "Content-Length": str(len(content)),
+                    LAST_MODIFIED: LAST_MODIFIED_DATE,
+                },
             ),
             200,
         )

--- a/tests/server_stubs/competition_download_stub.py
+++ b/tests/server_stubs/competition_download_stub.py
@@ -1,0 +1,77 @@
+import hashlib
+import os
+from collections.abc import Generator
+from typing import Any
+
+from flask import Flask, Response, jsonify
+from flask.typing import ResponseReturnValue
+
+from kagglehub.integrity import to_b64_digest
+from tests.utils import get_test_file_path
+
+app = Flask(__name__)
+
+TARGZ_ARCHIVE_HANDLE = "king-of the-targz"
+
+# See https://cloud.google.com/storage/docs/xml-api/reference-headers#xgooghash
+GCS_HASH_HEADER = "x-goog-hash"
+
+
+@app.route("/", methods=["HEAD"])
+def head() -> ResponseReturnValue:
+    return "", 200
+
+
+@app.route("/api/v1/competitions/data/download-all/<competition_slug>", methods=["GET"])
+def competition_download(competition_slug: str) -> ResponseReturnValue:
+    handle = f"{competition_slug}"
+
+    test_file_path = get_test_file_path("foo.txt.zip")
+    content_type = "application/zip"
+
+    if handle in TARGZ_ARCHIVE_HANDLE:
+        test_file_path = get_test_file_path("archive.tar.gz")
+        content_type = "application/x-gzip"
+
+    with open(test_file_path, "rb") as f:
+        content = f.read()
+        file_hash = hashlib.md5()
+        file_hash.update(content)
+        resp = Response()
+        resp.headers[GCS_HASH_HEADER] = f"md5={to_b64_digest(file_hash)}"
+        resp.content_type = content_type
+        resp.content_length = os.path.getsize(test_file_path)
+        resp.data = content
+        return resp, 200
+
+
+@app.route("/api/v1/competitions/data/download/<competition_slug>/<file_name>", methods=["GET"])
+def competition_download_file(competition_slug: str, file_name: str) -> ResponseReturnValue:
+    _ = f"{competition_slug}"
+    test_file_path = get_test_file_path(file_name)
+
+    def generate_file_content() -> Generator[bytes, Any, None]:
+        with open(test_file_path, "rb") as f:
+            while True:
+                chunk = f.read(4096)  # Read file in chunks
+                if not chunk:
+                    break
+                yield chunk
+
+    with open(test_file_path, "rb") as f:
+        content = f.read()
+        file_hash = hashlib.md5()
+        file_hash.update(content)
+        return (
+            Response(
+                generate_file_content(),
+                headers={GCS_HASH_HEADER: f"md5={to_b64_digest(file_hash)}", "Content-Length": str(len(content))},
+            ),
+            200,
+        )
+
+
+@app.errorhandler(404)
+def error(e: Exception):  # noqa: ANN201
+    data = {"message": "Some response data", "error": str(e)}
+    return jsonify(data), 404

--- a/tests/test_handle.py
+++ b/tests/test_handle.py
@@ -1,4 +1,4 @@
-from kagglehub.handle import parse_dataset_handle, parse_model_handle
+from kagglehub.handle import parse_competition_handle, parse_dataset_handle, parse_model_handle
 from tests.fixtures import BaseTestCase
 
 
@@ -57,3 +57,15 @@ class TestHandle(BaseTestCase):
         self.assertEqual(2, h.version)
         self.assertTrue(h.is_versioned())
         self.assertEqual(handle, str(h))
+
+    def test_invalid_competition_handle(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_competition_handle("owner/slug/does/not/needed/only/competition/slug")
+
+    def test_competition_handle(self) -> None:
+        handle = "titanic"
+
+        h = parse_competition_handle(handle)
+
+        self.assertEqual("", h.owner)
+        self.assertEqual("titanic", h.competition)

--- a/tests/test_handle.py
+++ b/tests/test_handle.py
@@ -67,5 +67,4 @@ class TestHandle(BaseTestCase):
 
         h = parse_competition_handle(handle)
 
-        self.assertEqual("", h.owner)
         self.assertEqual("titanic", h.competition)

--- a/tests/test_handle.py
+++ b/tests/test_handle.py
@@ -60,7 +60,7 @@ class TestHandle(BaseTestCase):
 
     def test_invalid_competition_handle(self) -> None:
         with self.assertRaises(ValueError):
-            parse_competition_handle("owner/slug/does/not/needed/only/competition/slug")
+            parse_competition_handle("ownerSlugNotNeeded/onlyCompetitionSlug")
 
     def test_competition_handle(self) -> None:
         handle = "titanic"

--- a/tests/test_http_competition_download.py
+++ b/tests/test_http_competition_download.py
@@ -15,7 +15,6 @@ from .utils import create_test_cache
 
 INVALID_ARCHIVE_COMPETITION_HANDLE = "invalid/invalid"
 COMPETITION_HANDLE = "titanic"
-COMPETITION_2_HANDLE = "titanic"
 TEST_FILEPATH = "foo.txt"
 TEST_CONTENTS = "foo"
 

--- a/tests/test_http_competition_download.py
+++ b/tests/test_http_competition_download.py
@@ -1,5 +1,8 @@
 import os
+from datetime import datetime, timezone
 from typing import Optional
+
+import requests
 
 import kagglehub
 from kagglehub.cache import COMPETITIONS_CACHE_SUBFOLDER, get_cached_archive_path
@@ -64,8 +67,8 @@ class TestHttpCompetitionDownload(BaseTestCase):
         competition_path = kagglehub.competition_download(competition_handle, path=TEST_FILEPATH, **kwargs)
 
         self.assertEqual(os.path.join(d, EXPECTED_COMPETITION_SUBPATH), competition_path)
-        with open(competition_path) as model_file:
-            self.assertEqual(TEST_CONTENTS, model_file.readline())
+        with open(competition_path) as competition_file:
+            self.assertEqual(TEST_CONTENTS, competition_file.readline())
 
     def test_competition_download(self) -> None:
         with create_test_cache() as d:
@@ -98,6 +101,69 @@ class TestHttpCompetitionDownload(BaseTestCase):
                 d, COMPETITION_HANDLE, EXPECTED_COMPETITION_SUBDIR, force_download=True
             )
 
+    def test_competition_download_ignored_cache_when_lastest_is_newer(self) -> None:
+        with create_test_cache() as d:
+            path = kagglehub.competition_download(COMPETITION_HANDLE)
+            # force cached file to be out of date. We set it back to March 02 2000.
+            test_date = 951955200
+            os.utime(os.path.join(d, EXPECTED_COMPETITION_SUBDIR), (test_date, test_date))
+            old_date = datetime.fromtimestamp(os.path.getmtime(path), tz=timezone.utc)
+
+            # Latest version is from March 02 2020.
+            path = kagglehub.competition_download(COMPETITION_HANDLE)
+
+            # New cache file is current day.
+            new_date = datetime.fromtimestamp(os.path.getmtime(path), tz=timezone.utc)
+            self.assertEqual(os.path.join(d, EXPECTED_COMPETITION_SUBDIR), path)
+            self.assertGreater(new_date, old_date)
+
     def test_competition_download_with_path(self) -> None:
         with create_test_cache() as d:
             self._download_test_file_and_assert_downloaded(d, COMPETITION_HANDLE)
+
+
+class TestHttpNoInternet(BaseTestCase):
+    @classmethod
+    def setUpClass(cls):
+        os.environ["KAGGLE_USERNAME"] = "fakeUser"
+        os.environ["KAGGLE_KEY"] = "fakeKaggleKey"
+
+    def test_competition_download_already_cached_with_no_internet(self) -> None:
+        with create_test_cache() as d:
+            server = serv.start_server(stub.app)
+            kagglehub.competition_download(COMPETITION_HANDLE)
+            server.shutdown()
+
+            path = kagglehub.competition_download(COMPETITION_HANDLE)
+
+            self.assertEqual(os.path.join(d, EXPECTED_COMPETITION_SUBDIR), path)
+
+    def test_competition_download_path_already_cached_with_no_internet(self) -> None:
+        with create_test_cache() as d:
+            server = serv.start_server(stub.app)
+            path = kagglehub.competition_download(COMPETITION_HANDLE, path=TEST_FILEPATH)
+            server.shutdown()
+
+            path = kagglehub.competition_download(COMPETITION_HANDLE, path=TEST_FILEPATH)
+
+            self.assertEqual(os.path.join(d, EXPECTED_COMPETITION_SUBPATH), path)
+
+    def test_competition_download_already_cached_with_force_download_no_internet(self) -> None:
+        with create_test_cache():
+            server = serv.start_server(stub.app)
+            kagglehub.competition_download(COMPETITION_HANDLE)
+            server.shutdown()
+
+            # No internet should throw an error.
+            with self.assertRaises(requests.exceptions.ConnectionError):
+                kagglehub.competition_download(COMPETITION_HANDLE, force_download=True)
+
+    def test_competition_download_with_path_already_cached_with_force_download_no_internet(self) -> None:
+        with create_test_cache():
+            server = serv.start_server(stub.app)
+            kagglehub.competition_download(COMPETITION_HANDLE, path=TEST_FILEPATH)
+            server.shutdown()
+
+            # No internet should throw an error.
+            with self.assertRaises(requests.exceptions.ConnectionError):
+                kagglehub.competition_download(COMPETITION_HANDLE, path=TEST_FILEPATH, force_download=True)

--- a/tests/test_http_competition_download.py
+++ b/tests/test_http_competition_download.py
@@ -1,0 +1,101 @@
+import os
+from typing import Optional
+
+import kagglehub
+from kagglehub.cache import COMPETITIONS_CACHE_SUBFOLDER, get_cached_archive_path
+from kagglehub.handle import parse_competition_handle
+from tests.fixtures import BaseTestCase
+
+from .server_stubs import competition_download_stub as stub
+from .server_stubs import serv
+from .utils import create_test_cache
+
+INVALID_ARCHIVE_COMPETITION_HANDLE = "invalid/invalid"
+COMPETITION_HANDLE = "titanic"
+COMPETITION_2_HANDLE = "titanic"
+TEST_FILEPATH = "foo.txt"
+TEST_CONTENTS = "foo"
+
+EXPECTED_COMPETITION_SUBDIR = os.path.join(COMPETITIONS_CACHE_SUBFOLDER, "titanic")
+EXPECTED_COMPETITION_SUBPATH = os.path.join(
+    COMPETITIONS_CACHE_SUBFOLDER,
+    "titanic",
+    TEST_FILEPATH,
+)
+
+
+class TestHttpCompetitionDownload(BaseTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.server = serv.start_server(stub.app)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+
+    def _download_competition_and_assert_downloaded(
+        self,
+        d: str,
+        competition_handle: str,
+        expected_subdir_or_subpath: str,
+        expected_files: Optional[list[str]] = None,
+        **kwargs,  # noqa: ANN003
+    ) -> None:
+        if not expected_files:
+            expected_files = ["foo.txt"]
+
+        # Download the full competitions and ensure all files are there.
+        competition_path = kagglehub.competition_download(competition_handle, **kwargs)
+        archive_path = get_cached_archive_path(parse_competition_handle(competition_handle))
+
+        self.assertEqual(os.path.join(d, expected_subdir_or_subpath), competition_path)
+        self.assertEqual(sorted(expected_files), sorted(os.listdir(competition_path)))
+        # Assert that the archive file has been deleted
+        self.assertFalse(os.path.exists(archive_path))
+
+    def _download_test_file_and_assert_downloaded(
+        self,
+        d: str,
+        competition_handle: str,
+        **kwargs,  # noqa: ANN003
+    ) -> None:
+        competition_path = kagglehub.competition_download(competition_handle, path=TEST_FILEPATH, **kwargs)
+
+        self.assertEqual(os.path.join(d, EXPECTED_COMPETITION_SUBPATH), competition_path)
+        with open(competition_path) as model_file:
+            self.assertEqual(TEST_CONTENTS, model_file.readline())
+
+    def test_competition_download(self) -> None:
+        with create_test_cache() as d:
+            self._download_competition_and_assert_downloaded(d, COMPETITION_HANDLE, EXPECTED_COMPETITION_SUBDIR)
+
+    def test_competition_targz_archive_download(self) -> None:
+        with create_test_cache() as d:
+            self._download_competition_and_assert_downloaded(
+                d,
+                stub.TARGZ_ARCHIVE_HANDLE,
+                f"{COMPETITIONS_CACHE_SUBFOLDER}/{stub.TARGZ_ARCHIVE_HANDLE}",
+                expected_files=[f"{i}.txt" for i in range(1, 51)],
+            )
+
+    def test_competition_download_bad_archive(self) -> None:
+        with create_test_cache():
+            with self.assertRaises(ValueError):
+                kagglehub.competition_download(INVALID_ARCHIVE_COMPETITION_HANDLE)
+
+    def test_competition_full_download_with_file_already_cached(self) -> None:
+        with create_test_cache() as d:
+            # Download a single file first
+            kagglehub.competition_download(COMPETITION_HANDLE, path=TEST_FILEPATH)
+
+            self._download_competition_and_assert_downloaded(d, COMPETITION_HANDLE, EXPECTED_COMPETITION_SUBDIR)
+
+    def test_competition_download_with_force_download(self) -> None:
+        with create_test_cache() as d:
+            self._download_competition_and_assert_downloaded(
+                d, COMPETITION_HANDLE, EXPECTED_COMPETITION_SUBDIR, force_download=True
+            )
+
+    def test_competition_download_with_path(self) -> None:
+        with create_test_cache() as d:
+            self._download_test_file_and_assert_downloaded(d, COMPETITION_HANDLE)

--- a/tests/test_http_competition_download.py
+++ b/tests/test_http_competition_download.py
@@ -28,6 +28,8 @@ class TestHttpCompetitionDownload(BaseTestCase):
     @classmethod
     def setUpClass(cls):
         cls.server = serv.start_server(stub.app)
+        os.environ["KAGGLE_USERNAME"] = "fakeUser"
+        os.environ["KAGGLE_KEY"] = "fakeKaggleKey"
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
This is part 1 of 2  for download competition dataset via kagglehub.
higher level view

competition_download takes in
- competition slug (which is unique)
- path (to perform single file downloads) (similar to dataset download)
- force download - (similar to dataset download)

kaggle api (and this method as well) only let's users download latest competition dataset, which is intentional. 


a follow up PR, will implement the resolver to attach a competition dataset inside a Kaggle notebook

https://b.corp.google.com/issues/369206113
