### PR TITLE
Move Colab credentials to get_kaggle_credentials.

### DIFF
--- a/src/kagglehub/clients.py
+++ b/src/kagglehub/clients.py
@@ -15,7 +15,7 @@ from tqdm import tqdm
 
 import kagglehub
 from kagglehub.cache import delete_from_cache, get_cached_archive_path
-from kagglehub.config import get_colab_credentials, get_kaggle_api_endpoint, get_kaggle_credentials
+from kagglehub.config import get_kaggle_api_endpoint, get_kaggle_credentials
 from kagglehub.env import (
     KAGGLE_DATA_PROXY_URL_ENV_VAR_NAME,
     KAGGLE_TOKEN_KEY_DIR_ENV_VAR_NAME,
@@ -205,8 +205,6 @@ class KaggleApiV1Client:
             return HTTPBasicAuth(self.credentials.username, self.credentials.key)
         elif is_in_kaggle_notebook():
             return KaggleTokenAuth()
-        elif is_in_colab_notebook() and (colab_secret := get_colab_credentials()) is not None:
-            return HTTPBasicAuth(colab_secret.username, colab_secret.key)
         return None
 
     def _build_url(self, path: str) -> str:
@@ -380,8 +378,6 @@ class ColabClient:
             return HTTPBasicAuth(self.credentials.username, self.credentials.key)
         elif is_in_kaggle_notebook():
             return KaggleTokenAuth()
-        elif is_in_colab_notebook() and (colab_secret := get_colab_credentials()) is not None:
-            return HTTPBasicAuth(colab_secret.username, colab_secret.key)
         return None
 
 

--- a/src/kagglehub/config.py
+++ b/src/kagglehub/config.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
+from kagglehub.env import is_in_colab_notebook
+
 DEFAULT_CACHE_FOLDER = os.path.join(Path.home(), ".cache", "kagglehub")
 DEFAULT_KAGGLE_API_ENDPOINT = "https://www.kaggle.com"
 DEFAULT_KAGGLE_CREDENTIALS_FOLDER = os.path.join(Path.home(), ".kaggle")
@@ -93,6 +95,8 @@ def get_kaggle_credentials() -> Optional[KaggleApiCredentials]:
             return KaggleApiCredentials(
                 username=creds_dict[CREDENTIALS_JSON_USERNAME], key=creds_dict[CREDENTIALS_JSON_KEY]
             )
+    if is_in_colab_notebook() and (colab_secret := get_colab_credentials()) is not None:
+        return KaggleApiCredentials(username=colab_secret.username, key=colab_secret.key)
 
     return None
 


### PR DESCRIPTION
This ensures `kagglehub.whoami()` returns the proper value.

Before:
![BXwpPiA9ji38oMD](https://github.com/user-attachments/assets/70671496-69bf-4f93-8d4d-4d5c8c51b4d8)

After:
![7AErWSvipSVWx2m](https://github.com/user-attachments/assets/42ebfef0-c3a8-4d0a-9934-9352088c34c2)

Next: Fix `whoami()` for inside a Kaggle notebook.

http://b/372503113