### PR TITLE
whoami should return username when using Kaggle notebook token.

### DIFF
--- a/src/kagglehub/auth.py
+++ b/src/kagglehub/auth.py
@@ -2,6 +2,7 @@ import io
 import logging
 from collections.abc import Generator
 from contextlib import contextmanager
+from typing import Optional
 
 from kagglehub.clients import KaggleApiV1Client
 from kagglehub.config import get_kaggle_credentials, set_kaggle_credentials
@@ -111,13 +112,13 @@ def _notebook_login(validate_credentials: bool) -> None:  # noqa: FBT001
 
     login_button.on_click(on_click_login_button)
 
-
-def _validate_credentials_helper() -> None:
+def _validate_credentials_helper() -> Optional[str]:
     api_client = KaggleApiV1Client()
     response = api_client.get("/hello")
-    if "code" not in response:
+    if "userName" in response:
         _logger.info("Kaggle credentials successfully validated.")
-    elif response["code"] == INVALID_CREDENTIALS_ERROR:
+        return response["userName"]
+    elif "code"  in response and response["code"] == INVALID_CREDENTIALS_ERROR:
         _logger.error(
             "Invalid Kaggle credentials. You can check your credentials on the [Kaggle settings page](https://www.kaggle.com/settings/account)."
         )
@@ -148,10 +149,9 @@ def whoami() -> dict:
     Return a dictionary with the username of the authenticated Kaggle user or raise an error if unauthenticated.
     """
     try:
-        credentials = get_kaggle_credentials()
-        if credentials and credentials.username:
-            return {"username": credentials.username}
-        else:
-            raise UnauthenticatedError()
+        username = _validate_credentials_helper()
+        if username:
+            return {"username": username}
+        raise UnauthenticatedError()
     except Exception as e:
         raise UnauthenticatedError() from e

--- a/src/kagglehub/auth.py
+++ b/src/kagglehub/auth.py
@@ -149,6 +149,9 @@ def whoami() -> dict:
     """
     Return a dictionary with the username of the authenticated Kaggle user or raise an error if unauthenticated.
     """
+    api_client = KaggleApiV1Client()
+    if not api_client.has_credentials():
+        raise UnauthenticatedError()
     try:
         username = _validate_credentials_helper()
         if username:
@@ -156,3 +159,4 @@ def whoami() -> dict:
         raise UnauthenticatedError()
     except Exception as e:
         raise UnauthenticatedError() from e
+    

--- a/src/kagglehub/auth.py
+++ b/src/kagglehub/auth.py
@@ -125,6 +125,7 @@ def _validate_credentials_helper() -> Optional[str]:
         )
     else:
         _logger.warning("Unable to validate Kaggle credentials at this time.")
+    return None
 
 
 def login(validate_credentials: bool = True) -> None:  # noqa: FBT002, FBT001

--- a/src/kagglehub/auth.py
+++ b/src/kagglehub/auth.py
@@ -159,4 +159,3 @@ def whoami() -> dict:
         raise UnauthenticatedError()
     except Exception as e:
         raise UnauthenticatedError() from e
-    

--- a/src/kagglehub/auth.py
+++ b/src/kagglehub/auth.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from typing import Optional
 
 from kagglehub.clients import KaggleApiV1Client
-from kagglehub.config import get_kaggle_credentials, set_kaggle_credentials
+from kagglehub.config import set_kaggle_credentials
 from kagglehub.exceptions import UnauthenticatedError
 
 _logger = logging.getLogger(__name__)
@@ -112,13 +112,14 @@ def _notebook_login(validate_credentials: bool) -> None:  # noqa: FBT001
 
     login_button.on_click(on_click_login_button)
 
+
 def _validate_credentials_helper() -> Optional[str]:
     api_client = KaggleApiV1Client()
     response = api_client.get("/hello")
     if "userName" in response:
         _logger.info("Kaggle credentials successfully validated.")
         return response["userName"]
-    elif "code"  in response and response["code"] == INVALID_CREDENTIALS_ERROR:
+    elif "code" in response and response["code"] == INVALID_CREDENTIALS_ERROR:
         _logger.error(
             "Invalid Kaggle credentials. You can check your credentials on the [Kaggle settings page](https://www.kaggle.com/settings/account)."
         )

--- a/src/kagglehub/clients.py
+++ b/src/kagglehub/clients.py
@@ -201,8 +201,8 @@ class KaggleApiV1Client:
             return True
 
     def has_credentials(self) -> bool:
-        return self._get_auth() != None
-    
+        return self._get_auth() is not None
+
     def _get_auth(self) -> Optional[requests.auth.AuthBase]:
         if self.credentials:
             return HTTPBasicAuth(self.credentials.username, self.credentials.key)

--- a/src/kagglehub/clients.py
+++ b/src/kagglehub/clients.py
@@ -200,6 +200,9 @@ class KaggleApiV1Client:
 
             return True
 
+    def has_credentials(self) -> bool:
+        return self._get_auth() != None
+    
     def _get_auth(self) -> Optional[requests.auth.AuthBase]:
         if self.credentials:
             return HTTPBasicAuth(self.credentials.username, self.credentials.key)

--- a/src/kagglehub/http_resolver.py
+++ b/src/kagglehub/http_resolver.py
@@ -43,13 +43,10 @@ class CompetitionHttpResolver(Resolver[CompetitionHandle]):
             delete_from_cache(h, path)
             cached_path = None
 
-        try:
-            # Competition does not alllow for anonymous downloads.
-            _ = whoami()
-        except UnauthenticatedError:
+        if not api_client.has_credentials():
             if cached_path:
                 return cached_path
-            raise
+            raise UnauthenticatedError()
 
         out_path = get_cached_path(h, path)
         if path:

--- a/src/kagglehub/http_resolver.py
+++ b/src/kagglehub/http_resolver.py
@@ -7,7 +7,6 @@ from typing import Optional
 import requests
 from tqdm.contrib.concurrent import thread_map
 
-from kagglehub.auth import whoami
 from kagglehub.cache import (
     delete_from_cache,
     get_cached_archive_path,

--- a/tests/server_stubs/auth_stub.py
+++ b/tests/server_stubs/auth_stub.py
@@ -23,7 +23,7 @@ def error(e: Exception):  # noqa: ANN201
 def model_create() -> ResponseReturnValue:
     auth = request.authorization
     if auth and auth.username == GOOD_CREDENTIALS_USERNAME and auth.password == GOOD_CREDENTIALS_API_KEY:
-        data = {"message": "Hello from test server!"}
+        data = {"message": "Hello from test server!", "userName": auth.username}
         return jsonify(data), 200
     else:
         return jsonify({"code": 401}), 200


### PR DESCRIPTION
Similar to #165 (handling for Colab secrets) but this is for handling the default auth in Kaggle notebook.

Before, `whoami` would return unauthenticated when using default auth in Kaggle notebook:
![8MDxdhZc6YDfTJA](https://github.com/user-attachments/assets/fa09a46b-e6b0-4566-b476-1ac518b439c2)


After, `whoami` returns the current username: 
![8MRE8FFqpmCLSnL](https://github.com/user-attachments/assets/578be681-8edd-4857-bba6-5e24286642f2)


http://b/372524708