### PR TITLE
If auth env vars are empty, fallback to next auth mechanism

### DIFF
--- a/integration_tests/test_utils.py
+++ b/integration_tests/test_utils.py
@@ -1,0 +1,13 @@
+import unittest
+
+from kagglehub import whoami
+from kagglehub.exceptions import UnauthenticatedError
+
+from .utils import unauthenticated
+
+
+class TestUtils(unittest.TestCase):
+    def test_unauthenticated(self) -> None:
+        with unauthenticated():
+            with self.assertRaises(UnauthenticatedError):
+                whoami()

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -5,7 +5,12 @@ from contextlib import contextmanager
 from tempfile import TemporaryDirectory
 from unittest import mock
 
-from kagglehub.config import CACHE_FOLDER_ENV_VAR_NAME, KEY_ENV_VAR_NAME, USERNAME_ENV_VAR_NAME
+from kagglehub.config import (
+    CACHE_FOLDER_ENV_VAR_NAME,
+    CREDENTIALS_FOLDER_ENV_VAR_NAME,
+    KEY_ENV_VAR_NAME,
+    USERNAME_ENV_VAR_NAME,
+)
 
 
 @contextmanager
@@ -52,9 +57,6 @@ def assert_files(test_case: unittest.TestCase, path: str, expected_files: list[s
 def unauthenticated() -> Generator[None, None, None]:
     with mock.patch.dict(
         os.environ,
-        {
-            USERNAME_ENV_VAR_NAME: "",
-            KEY_ENV_VAR_NAME: "",
-        },
+        {USERNAME_ENV_VAR_NAME: "", KEY_ENV_VAR_NAME: "", CREDENTIALS_FOLDER_ENV_VAR_NAME: "/nonexistent"},
     ):
         yield

--- a/src/kagglehub/config.py
+++ b/src/kagglehub/config.py
@@ -74,7 +74,9 @@ def get_kaggle_credentials() -> Optional[KaggleApiCredentials]:
 
     creds_filepath = _get_kaggle_credentials_file()
 
-    if USERNAME_ENV_VAR_NAME in os.environ and KEY_ENV_VAR_NAME in os.environ:
+    env_var_username = os.getenv(USERNAME_ENV_VAR_NAME)
+    env_var_key = os.getenv(KEY_ENV_VAR_NAME)
+    if env_var_username and env_var_key:
         return KaggleApiCredentials(username=os.environ[USERNAME_ENV_VAR_NAME], key=os.environ[KEY_ENV_VAR_NAME])
     if os.path.exists(creds_filepath):
         with open(creds_filepath) as creds_json_file:


### PR DESCRIPTION
Currently, if the auth environment variables are set to empty strings, it uses the empty values rather than falling back to the next mechanism such as reading them from `kaggle.json`:

```
export KAGGLE_USERNAME=""
export KAGGLE_KEY=""
```

http://b/372933776