### PR TITLE
Hide api key when prompting.

### DIFF
--- a/src/kagglehub/auth.py
+++ b/src/kagglehub/auth.py
@@ -3,6 +3,7 @@ import logging
 from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Optional
+from getpass import getpass
 
 from kagglehub.clients import KaggleApiV1Client
 from kagglehub.config import set_kaggle_credentials
@@ -136,7 +137,7 @@ def login(validate_credentials: bool = True) -> None:  # noqa: FBT002, FBT001
         return
     else:
         username = input("Enter your Kaggle username: ")
-        api_key = input("Enter your Kaggle API key: ")
+        api_key = getpass("Enter your Kaggle API key (input will not be visible): ")
 
     set_kaggle_credentials(username=username, api_key=api_key)
 

--- a/src/kagglehub/auth.py
+++ b/src/kagglehub/auth.py
@@ -2,8 +2,8 @@ import io
 import logging
 from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Optional
 from getpass import getpass
+from typing import Optional
 
 from kagglehub.clients import KaggleApiV1Client
 from kagglehub.config import set_kaggle_credentials

--- a/src/kagglehub/auth.py
+++ b/src/kagglehub/auth.py
@@ -1,8 +1,8 @@
+import getpass
 import io
 import logging
 from collections.abc import Generator
 from contextlib import contextmanager
-from getpass import getpass
 from typing import Optional
 
 from kagglehub.clients import KaggleApiV1Client
@@ -137,7 +137,7 @@ def login(validate_credentials: bool = True) -> None:  # noqa: FBT002, FBT001
         return
     else:
         username = input("Enter your Kaggle username: ")
-        api_key = getpass("Enter your Kaggle API key (input will not be visible): ")
+        api_key = getpass.getpass("Enter your Kaggle API key (input will not be visible): ")
 
     set_kaggle_credentials(username=username, api_key=api_key)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -24,8 +24,10 @@ class TestAuth(BaseTestCase):
 
     def test_login_updates_global_credentials(self) -> None:
         with mock.patch("builtins.input") as mock_input:
-            mock_input.side_effect = ["lastplacelarry", "some-key"]
-            kagglehub.login()
+            with mock.patch("getpass.getpass") as mock_getpass:
+                mock_input.side_effect = ["lastplacelarry"]
+                mock_getpass.return_value = "some-key"
+                kagglehub.login()
 
         # Verify that the global variable contains the updated credentials
         credentials = get_kaggle_credentials()
@@ -35,10 +37,11 @@ class TestAuth(BaseTestCase):
         self.assertEqual("some-key", credentials.key)
 
     def test_login_updates_global_credentials_no_validation(self) -> None:
-        # Simulate user input for credentials
         with mock.patch("builtins.input") as mock_input:
-            mock_input.side_effect = ["lastplacelarry", "some-key"]
-            kagglehub.login(validate_credentials=False)
+            with mock.patch("getpass.getpass") as mock_getpass:
+                mock_input.side_effect = ["lastplacelarry"]
+                mock_getpass.return_value = "some-key"
+                kagglehub.login(validate_credentials=False)
 
         # Verify that the global variable contains the updated credentials
         credentials = get_kaggle_credentials()
@@ -50,28 +53,36 @@ class TestAuth(BaseTestCase):
     def test_set_kaggle_credentials_raises_error_with_empty_username(self) -> None:
         with self.assertRaises(ValueError):
             with mock.patch("builtins.input") as mock_input:
-                mock_input.side_effect = ["", "some-key"]
-                kagglehub.login()
+                with mock.patch("getpass.getpass") as mock_getpass:
+                    mock_input.side_effect = [""]
+                    mock_getpass.return_value = "some-key"
+                    kagglehub.login()
 
     def test_set_kaggle_credentials_raises_error_with_empty_api_key(self) -> None:
         with self.assertRaises(ValueError):
             with mock.patch("builtins.input") as mock_input:
-                mock_input.side_effect = ["lastplacelarry", ""]
-                kagglehub.login()
+                with mock.patch("getpass.getpass") as mock_getpass:
+                    mock_input.side_effect = ["lastplacelarry"]
+                    mock_getpass.return_value = ""
+                    kagglehub.login()
 
     def test_set_kaggle_credentials_raises_error_with_empty_username_api_key(self) -> None:
         with self.assertRaises(ValueError):
             with mock.patch("builtins.input") as mock_input:
-                mock_input.side_effect = ["", ""]
-                kagglehub.login()
+                with mock.patch("getpass.getpass") as mock_getpass:
+                    mock_input.side_effect = [""]
+                    mock_getpass.return_value = ""
+                    kagglehub.login()
 
     def test_login_returns_403_for_bad_credentials(self) -> None:
         output_stream = io.StringIO()
         handler = logging.StreamHandler(output_stream)
         logger.addHandler(handler)
         with mock.patch("builtins.input") as mock_input:
-            mock_input.side_effect = ["invalid", "invalid"]
-            kagglehub.login()
+            with mock.patch("getpass.getpass") as mock_getpass:
+                mock_input.side_effect = ["invalid"]
+                mock_getpass.return_value = "invalid"
+                kagglehub.login()
 
         captured_output = output_stream.getvalue()
         self.assertEqual(
@@ -92,8 +103,10 @@ class TestAuth(BaseTestCase):
 
     def test_whoami_success(self) -> None:
         with mock.patch("builtins.input") as mock_input:
-            mock_input.side_effect = ["lastplacelarry", "some-key"]
-            kagglehub.login(validate_credentials=False)
-            result = kagglehub.whoami()
+            with mock.patch("getpass.getpass") as mock_getpass:
+                mock_input.side_effect = ["lastplacelarry"]
+                mock_getpass.return_value = "some-key"
+                kagglehub.login(validate_credentials=False)
+                result = kagglehub.whoami()
 
-            self.assertEqual(result, {"username": "lastplacelarry"})
+                self.assertEqual(result, {"username": "lastplacelarry"})


### PR DESCRIPTION
Prevent it from appearing in the terminal and the commands history.

Screenshot: https://screenshot.googleplex.com/efgRsvG8DS4Arbx

http://b/373985867