### PR TITLE
feat(models): add output_dir option to model_download

### DIFF
--- a/src/kagglehub/models.py
+++ b/src/kagglehub/models.py
@@ -1,4 +1,5 @@
 import logging
+from shutil import copytree
 from typing import Optional, Union
 
 from kagglehub import registry
@@ -13,22 +14,44 @@ logger = logging.getLogger(__name__)
 DEFAULT_IGNORE_PATTERNS = [".git/", "*/.git/", ".cache/", ".huggingface/"]
 
 
-def model_download(handle: str, path: Optional[str] = None, *, force_download: Optional[bool] = False) -> str:
+def model_download(
+    handle: str,
+    path: Optional[str] = None,
+    *,
+    force_download: Optional[bool] = False,
+    output_dir: Optional[str] = None) -> str:
     """Download model files.
 
     Args:
         handle: (string) the model handle.
         path: (string) Optional path to a file within the model bundle.
         force_download: (bool) Optional flag to force download a model, even if it's cached.
-
+        output_dir: (str) Optional path to copy model files to after successful download.
 
     Returns:
         A string representing the path to the requested model files.
     """
     h = parse_model_handle(handle)
     logger.info(f"Downloading Model: {h.to_url()} ...", extra={**EXTRA_CONSOLE_BLOCK})
-    return registry.model_resolver(h, path, force_download=force_download)
+    cached_dir = registry.model_resolver(h, path, force_download=force_download)
 
+    if output_dir is None:
+        return cached_dir
+
+    try:
+        # only copying so that we can maintain the cached files
+        logger.info(
+            f"Copying model files to requested directory: {output_dir} ...",
+            extra={**EXTRA_CONSOLE_BLOCK}
+        )
+        true_output_dir = copytree(cached_dir, output_dir, dirs_exist_ok=True)
+        return true_output_dir
+    except Exception as e:
+        logger.warn(
+            f"Successfully downloaded {handle}, but failed to copy from {cached_dir} "
+            f"to requested output directory {output_dir}. Encountered error: {e}"
+        )
+        return cached_dir
 
 def model_upload(
     handle: str,


### PR DESCRIPTION
BUG=b/377340841 (for googlers)

Adds support for an `output_dir` argument, similar to HuggingFace Hub's [`local_dir`](https://huggingface.co/docs/huggingface_hub/en/guides/download#download-files-to-a-local-folder). 

This change is primarily motivated by this torchtune RFC: https://github.com/pytorch/torchtune/issues/1852#issuecomment-2418270469

While we could use a stopgap solution and copy files within torchtune, this behavior is general enough that direct `kagglehub` users could benefit from it.