### PR TITLE
Prepare 0.3.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.4 (November 8th, 2024)
+
+* Add a naive Colab dataset cache resolver ([#177](https://github.com/Kaggle/kagglehub/pull/177))
+* Add `keras_hub` as user-agent ([#176](https://github.com/Kaggle/kagglehub/pull/176))
+
 ## v0.3.3 (October 17th, 2024)
 
 * Hide API key in terminal when prompting in `kaggle.login(...)` ([#173](https://github.com/Kaggle/kagglehub/pull/173))

--- a/src/kagglehub/__init__.py
+++ b/src/kagglehub/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 import kagglehub.logger  # configures the library logger.
 from kagglehub import colab_cache_resolver, http_resolver, kaggle_cache_resolver, registry


### PR DESCRIPTION
Cutting a new release to include the Colab dataset cache resolver (new release requested by the Colab team).