### PR TITLE
Include IAP token in JWT requests to webtier.

### DIFF
--- a/src/kagglehub/clients.py
+++ b/src/kagglehub/clients.py
@@ -320,7 +320,7 @@ class KaggleJwtClient:
 
         iap_token = os.getenv(KAGGLE_IAP_TOKEN_ENV_VAR_NAME)
         if iap_token:
-            self.headers['Authorization'] = f'Bearer {iap_token}'
+            self.headers["Authorization"] = f"Bearer {iap_token}"
 
     def post(
         self,

--- a/src/kagglehub/clients.py
+++ b/src/kagglehub/clients.py
@@ -285,6 +285,7 @@ def _download_needed(response: requests.Response, h: ResourceHandle, cached_path
 # These environment variables are set by the Kaggle notebook environment.
 KAGGLE_JWT_TOKEN_ENV_VAR_NAME = "KAGGLE_USER_SECRETS_TOKEN"
 KAGGLE_DATA_PROXY_TOKEN_ENV_VAR_NAME = "KAGGLE_DATA_PROXY_TOKEN"
+KAGGLE_IAP_TOKEN_ENV_VAR_NAME = "KAGGLE_IAP_TOKEN"
 
 
 class KaggleJwtClient:
@@ -316,6 +317,10 @@ class KaggleJwtClient:
             "X-Kaggle-Authorization": f"Bearer {jwt_token}",
             "X-KAGGLE-PROXY-DATA": data_proxy_token,
         }
+
+        iap_token = os.getenv(KAGGLE_IAP_TOKEN_ENV_VAR_NAME)
+        if iap_token:
+            self.headers['Authorization'] = f'Bearer {iap_token}'
 
     def post(
         self,

--- a/src/kagglehub/gcs_upload.py
+++ b/src/kagglehub/gcs_upload.py
@@ -10,7 +10,7 @@ from tempfile import TemporaryDirectory
 from typing import Optional, Union
 
 import requests
-from requests.exceptions import ConnectionError, Timeout
+from requests.exceptions import Timeout
 from tqdm import tqdm
 from tqdm.utils import CallbackIOWrapper
 
@@ -66,7 +66,7 @@ class File(object):  # noqa: UP004
         while size >= 1024 and suffix_index < 4:  # noqa: PLR2004
             suffix_index += 1
             size /= 1024.0
-        return "%.*f%s" % (precision, size, suffixes[suffix_index])
+        return f"{size:.{precision}f}{suffixes[suffix_index]}"
 
 
 def filtered_walk(*, base_dir: str, ignore_patterns: Sequence[str]) -> Iterable[tuple[str, list[str], list[str]]]:
@@ -109,7 +109,7 @@ def _check_uploaded_size(session_uri: str, file_size: int, backoff_factor: int =
                 return 0  # If no Range header, assume no bytes were uploaded
             else:
                 return file_size
-        except (ConnectionError, Timeout):
+        except (requests.ConnectionError, Timeout):
             logger.info(f"Network issue while checking uploaded size, retrying in {backoff_factor} seconds...")
             time.sleep(backoff_factor)
             backoff_factor = min(backoff_factor * 2, 60)


### PR DESCRIPTION
This will ensures that checks for `CurrentUser.IsAdmin` will work as expected to avoid issues like: https://b.corp.google.com/issues/381445306#comment8

http://b/381445306