### PR TITLE
Update `docker-hatch` and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Ignore python files at the root of the repo, which might be used for testing commands like:
+# ./docker-hatch run python my-script.py
+/*.py

--- a/README.md
+++ b/README.md
@@ -205,9 +205,31 @@ hatch test integration_tests
 
 ### Run `kagglehub` from source
 
+#### Option 1: Execute a one-liner of code from the command line
+
 ```sh
 # Download a model & print the path
 hatch run python -c "import kagglehub; print('path: ', kagglehub.model_download('google/bert/tensorFlow2/answer-equivalence-bem'))"
+```
+
+#### Option 2: Run a saved script from the /tools/scripts directory
+
+```sh
+# This runs the same code as the one-liner above, but reads it from a 
+# checked in script located at tool/scripts/download_model.py
+hatch run python tools/scripts/download_model.py
+```
+
+#### Option 3: Run a temporary script from the root of the repo
+
+Any script created at the root of the repo is gitignore'd, so they're
+just temporary scripts for testing in development. Placing temporary 
+scripts at the root makes the run command easier to use during local 
+development.
+
+```sh
+# Test out some new changes
+hatch run python test_new_feature.py
 ```
 
 ### Lint / Format
@@ -249,6 +271,12 @@ The following shows how to run `hatch run lint:all` but this also works for any 
 
 # Run test in docker with specific Python version
 ./docker-hatch -v 3.9 test
+
+# Run python from specific environment (e.g. one with optional dependencies installed)
+./docker-hatch run extra-deps-env:python -c "print('hello world')"
+
+# Run commands with other root-level hatch options (everything after -- gets passed to hatch)
+./docker-hatch -v 3.9 -- -v env create debug-env-with-verbose-logging
 ```
 
 ## VS Code setup

--- a/docker-hatch
+++ b/docker-hatch
@@ -10,8 +10,9 @@ Usage: $0 [OPTIONS] HATCH-OPTIONS-COMMAND-ARGS
 Run the given HATCH-OPTIONS-COMMAND-ARGS in a container.
 
 Options:
+    -h, --help                              Show documentation on how to use $0
     -v, --python-version PYTHON-VERSION     Run in a container using this specfic Python version.
-                                            Valid versions are tags of the `python` Docker image: https://hub.docker.com/_/python
+                                            Valid versions are tags of the \`python\` Docker image: https://hub.docker.com/_/python
     -f, --force-rebuild-docker-image        Force re-build the Docker image.
 EOF
 }
@@ -33,6 +34,11 @@ while :; do
             ;;
         -f|--force-rebuild-docker-image)
             CACHE_FLAG='--no-cache'
+            ;;
+        # Use this marker to indicate that the rest of the command is for hatch
+        --)
+            shift # skip this one to pass the rest to hatch  
+            break
             ;;
         -?*)
             usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,10 @@ skip-string-normalization = true
 [tool.ruff]
 target-version = "py39"
 line-length = 120
+extend-exclude = [
+  # Ignore saved scripts for local kagglehub testing
+  "tools/scripts/*",
+]
 
 [tool.ruff.lint]
 select = [

--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -1,0 +1,5 @@
+# Kaggle Hub Saved Scripts
+
+The scripts in this directory are just examples of how to test `kagglehub` while developing
+locally. See [the main README](../../README.md#option-2-run-a-saved-script-from-the-toolsscripts-directory)
+for more details on how to run them.

--- a/tools/scripts/download_model.py
+++ b/tools/scripts/download_model.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+import kagglehub
+
+print("path: ", kagglehub.model_download("google/bert/tensorFlow2/answer-equivalence-bem"))  # noqa: T201

--- a/tools/scripts/download_model.py
+++ b/tools/scripts/download_model.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 import kagglehub
 
-print("path: ", kagglehub.model_download("google/bert/tensorFlow2/answer-equivalence-bem"))  # noqa: T201
+print("path: ", kagglehub.model_download("google/bert/tensorFlow2/answer-equivalence-bem"))


### PR DESCRIPTION
Notes:
- Add a marker flag (with documentation) to indicate when the remaining args should pass through to hatch
- Fixed a bug where `usage` would start a `python` shell
- Other changes just help document some slightly easier ways to run python commands when using hatch instead of having to force everything into a long, inconvenient one-liner

http://b/379756505