### PR TITLE
Pin metadata-version to 2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,15 @@ dependencies = [
 hf-datasets = ["datasets", "kagglehub[pandas-datasets]"]
 pandas-datasets = ["pandas"]
 
+
+# twine 6.0.1 doesn't support metadata-version 2.4.
+# remove `core-metadata-version` pin once twine release a new version with: https://github.com/pypa/twine/pull/1180
+[tool.hatch.build.targets.wheel]
+core-metadata-version = "2.3" 
+
+[tool.hatch.build.targets.sdist]
+core-metadata-version = "2.3"
+
 [tool.hatch.version]
 path = "src/kagglehub/__init__.py"
 

--- a/tools/release/cloudbuild.yaml
+++ b/tools/release/cloudbuild.yaml
@@ -120,6 +120,6 @@ steps:
 
 substitutions:
   _GITHUB_REPOSITORY: kagglehub
-  _PYTHON_VERSION: 3.9.18
+  _PYTHON_VERSION: 3.9.19
   _NEW_VERSION: default
 


### PR DESCRIPTION
`twine` 6.0.1 doesn't support metadata-version 2.4.