### PR TITLE
Pin hatch & twine, add .ruff_cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,9 @@ dmypy.json
 # pytype static type analyzer
 .pytype/
 
+# Python linter
+.ruff_cache/
+
 # Cython debug symbols
 cython_debug/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG PYTHON_VERSION
 
 FROM python:${PYTHON_VERSION}
 
-RUN pip install hatch==1.12.0
+RUN pip install hatch==1.14.0
 
 # Add only the minimal files required to be able to pre-create the hatch environments.
 # If any of these files changes, a new Docker build is necessary. This is why we need

--- a/tools/cicd/Dockerfile
+++ b/tools/cicd/Dockerfile
@@ -6,6 +6,6 @@ ARG PYTHON_VERSION
 
 FROM python:${PYTHON_VERSION}
 
-RUN python -m pip install hatch twine
+RUN python -m pip install hatch==1.14.0 twine==6.0.1
 
 ENTRYPOINT ["hatch"]

--- a/tools/release/cloudbuild.yaml
+++ b/tools/release/cloudbuild.yaml
@@ -17,106 +17,106 @@ steps:
       exit 1
     fi
 
-# Get the GitHub access token from Secret Manager.
-# The token is used to talk to GitHub API, specifically to create a release.
-- name: gcr.io/cloud-builders/gcloud
-  id: 'github-token'
-  entrypoint: 'bash'
-  args: 
-  - '-c'
-  - 'gcloud secrets versions access latest --secret=kaggleteam-github-access-token > /root/github_token'
-  volumes:
-  - name: 'root'
-    path: /root
+# # Get the GitHub access token from Secret Manager.
+# # The token is used to talk to GitHub API, specifically to create a release.
+# - name: gcr.io/cloud-builders/gcloud
+#   id: 'github-token'
+#   entrypoint: 'bash'
+#   args: 
+#   - '-c'
+#   - 'gcloud secrets versions access latest --secret=kaggleteam-github-access-token > /root/github_token'
+#   volumes:
+#   - name: 'root'
+#     path: /root
 
-# Get the pypi password from Secret Manager, and create the ~/.pypirc file.
-- name: 'gcr.io/cloud-builders/gcloud'
-  id: create-credentials-pypirc
-  entrypoint: 'bash'
-  args:
-    - '-c'
-    - |
-      token_test=$(gcloud secrets versions access latest --secret=test-pypi-token)
-      token=$(gcloud secrets versions access latest --secret=pypi-token)
-      cat >~/.pypirc <<EOL
-      [distutils]
-      index-servers =
-        pypi
-        pypitest
-      [pypi]
-      repository: https://upload.pypi.org/legacy/
-      username=__token__
-      password=${token}
-      [pypitest]
-      repository: https://test.pypi.org/legacy/
-      username=__token__
-      password=${token_test}
-      EOL
-  volumes:
-  - name: 'root'
-    path: /root
+# # Get the pypi password from Secret Manager, and create the ~/.pypirc file.
+# - name: 'gcr.io/cloud-builders/gcloud'
+#   id: create-credentials-pypirc
+#   entrypoint: 'bash'
+#   args:
+#     - '-c'
+#     - |
+#       token_test=$(gcloud secrets versions access latest --secret=test-pypi-token)
+#       token=$(gcloud secrets versions access latest --secret=pypi-token)
+#       cat >~/.pypirc <<EOL
+#       [distutils]
+#       index-servers =
+#         pypi
+#         pypitest
+#       [pypi]
+#       repository: https://upload.pypi.org/legacy/
+#       username=__token__
+#       password=${token}
+#       [pypitest]
+#       repository: https://test.pypi.org/legacy/
+#       username=__token__
+#       password=${token_test}
+#       EOL
+#   volumes:
+#   - name: 'root'
+#     path: /root
 
-# Pull the repository from GitHub.
-- name: 'gcr.io/cloud-builders/git'
-  id: clone-repo
-  args:
-  - clone
-  - https://github.com/kaggle/$_GITHUB_REPOSITORY.git
+# # Pull the repository from GitHub.
+# - name: 'gcr.io/cloud-builders/git'
+#   id: clone-repo
+#   args:
+#   - clone
+#   - https://github.com/kaggle/$_GITHUB_REPOSITORY.git
 
-# The hatch docker image is built with the tools/cicd/cloudbuild.yaml build.
-- name: us-docker.pkg.dev/$PROJECT_ID/tools/hatch:${_PYTHON_VERSION}
-  id: tests
-  dir: $_GITHUB_REPOSITORY
-  args:
-  - test
+# # The hatch docker image is built with the tools/cicd/cloudbuild.yaml build.
+# - name: us-docker.pkg.dev/$PROJECT_ID/tools/hatch:${_PYTHON_VERSION}
+#   id: tests
+#   dir: $_GITHUB_REPOSITORY
+#   args:
+#   - test
 
-- name: us-docker.pkg.dev/$PROJECT_ID/tools/hatch:${_PYTHON_VERSION}
-  id: lint
-  dir: $_GITHUB_REPOSITORY
-  args:
-  - run
-  - lint:all
+# - name: us-docker.pkg.dev/$PROJECT_ID/tools/hatch:${_PYTHON_VERSION}
+#   id: lint
+#   dir: $_GITHUB_REPOSITORY
+#   args:
+#   - run
+#   - lint:all
 
-- name: us-docker.pkg.dev/$PROJECT_ID/tools/hatch:${_PYTHON_VERSION}
-  id: build
-  dir: $_GITHUB_REPOSITORY
-  args:
-  - build
+# - name: us-docker.pkg.dev/$PROJECT_ID/tools/hatch:${_PYTHON_VERSION}
+#   id: build
+#   dir: $_GITHUB_REPOSITORY
+#   args:
+#   - build
 
-# Create a release on GitHub.
-# The `hub` image has been built previously in the project:
-# $ git clone https://github.com/GoogleCloudPlatform/cloud-builders-community.git
-# $ cd cloud-builders-community/hub
-# $ gcloud builds submit
-- name: 'us-docker.pkg.dev/$PROJECT_ID/tools/hub'
-  id: 'release'
-  dir: $_GITHUB_REPOSITORY
-  entrypoint: 'bash'
-  args:
-  - '-c'
-  - |
-    export GITHUB_TOKEN=$(</root/github_token)
-    hub release create -m "release v$_NEW_VERSION" "v$_NEW_VERSION"
-  env:
-  - GITHUB_USER=kaggle
-  - GITHUB_REPOSITORY=$_GITHUB_REPOSITORY
-  - HUB_PROTOCOL=https
-  volumes:
-  - name: 'root'
-    path: /root
+# # Create a release on GitHub.
+# # The `hub` image has been built previously in the project:
+# # $ git clone https://github.com/GoogleCloudPlatform/cloud-builders-community.git
+# # $ cd cloud-builders-community/hub
+# # $ gcloud builds submit
+# - name: 'us-docker.pkg.dev/$PROJECT_ID/tools/hub'
+#   id: 'release'
+#   dir: $_GITHUB_REPOSITORY
+#   entrypoint: 'bash'
+#   args:
+#   - '-c'
+#   - |
+#     export GITHUB_TOKEN=$(</root/github_token)
+#     hub release create -m "release v$_NEW_VERSION" "v$_NEW_VERSION"
+#   env:
+#   - GITHUB_USER=kaggle
+#   - GITHUB_REPOSITORY=$_GITHUB_REPOSITORY
+#   - HUB_PROTOCOL=https
+#   volumes:
+#   - name: 'root'
+#     path: /root
 
-# Release package to pypi.
-- name: us-docker.pkg.dev/$PROJECT_ID/tools/hatch:${_PYTHON_VERSION}
-  id: release-pypi
-  dir: $_GITHUB_REPOSITORY
-  entrypoint: bash 
-  args:
-  - '-c'
-  - |
-    twine upload dist/* -r pypi
-  volumes:
-  - name: 'root'
-    path: /root
+# # Release package to pypi.
+# - name: us-docker.pkg.dev/$PROJECT_ID/tools/hatch:${_PYTHON_VERSION}
+#   id: release-pypi
+#   dir: $_GITHUB_REPOSITORY
+#   entrypoint: bash 
+#   args:
+#   - '-c'
+#   - |
+#     twine upload dist/* -r pypi
+#   volumes:
+#   - name: 'root'
+#     path: /root
 
 substitutions:
   _GITHUB_REPOSITORY: kagglehub

--- a/tools/release/cloudbuild.yaml
+++ b/tools/release/cloudbuild.yaml
@@ -17,106 +17,106 @@ steps:
       exit 1
     fi
 
-# # Get the GitHub access token from Secret Manager.
-# # The token is used to talk to GitHub API, specifically to create a release.
-# - name: gcr.io/cloud-builders/gcloud
-#   id: 'github-token'
-#   entrypoint: 'bash'
-#   args: 
-#   - '-c'
-#   - 'gcloud secrets versions access latest --secret=kaggleteam-github-access-token > /root/github_token'
-#   volumes:
-#   - name: 'root'
-#     path: /root
+# Get the GitHub access token from Secret Manager.
+# The token is used to talk to GitHub API, specifically to create a release.
+- name: gcr.io/cloud-builders/gcloud
+  id: 'github-token'
+  entrypoint: 'bash'
+  args: 
+  - '-c'
+  - 'gcloud secrets versions access latest --secret=kaggleteam-github-access-token > /root/github_token'
+  volumes:
+  - name: 'root'
+    path: /root
 
-# # Get the pypi password from Secret Manager, and create the ~/.pypirc file.
-# - name: 'gcr.io/cloud-builders/gcloud'
-#   id: create-credentials-pypirc
-#   entrypoint: 'bash'
-#   args:
-#     - '-c'
-#     - |
-#       token_test=$(gcloud secrets versions access latest --secret=test-pypi-token)
-#       token=$(gcloud secrets versions access latest --secret=pypi-token)
-#       cat >~/.pypirc <<EOL
-#       [distutils]
-#       index-servers =
-#         pypi
-#         pypitest
-#       [pypi]
-#       repository: https://upload.pypi.org/legacy/
-#       username=__token__
-#       password=${token}
-#       [pypitest]
-#       repository: https://test.pypi.org/legacy/
-#       username=__token__
-#       password=${token_test}
-#       EOL
-#   volumes:
-#   - name: 'root'
-#     path: /root
+# Get the pypi password from Secret Manager, and create the ~/.pypirc file.
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: create-credentials-pypirc
+  entrypoint: 'bash'
+  args:
+    - '-c'
+    - |
+      token_test=$(gcloud secrets versions access latest --secret=test-pypi-token)
+      token=$(gcloud secrets versions access latest --secret=pypi-token)
+      cat >~/.pypirc <<EOL
+      [distutils]
+      index-servers =
+        pypi
+        pypitest
+      [pypi]
+      repository: https://upload.pypi.org/legacy/
+      username=__token__
+      password=${token}
+      [pypitest]
+      repository: https://test.pypi.org/legacy/
+      username=__token__
+      password=${token_test}
+      EOL
+  volumes:
+  - name: 'root'
+    path: /root
 
-# # Pull the repository from GitHub.
-# - name: 'gcr.io/cloud-builders/git'
-#   id: clone-repo
-#   args:
-#   - clone
-#   - https://github.com/kaggle/$_GITHUB_REPOSITORY.git
+# Pull the repository from GitHub.
+- name: 'gcr.io/cloud-builders/git'
+  id: clone-repo
+  args:
+  - clone
+  - https://github.com/kaggle/$_GITHUB_REPOSITORY.git
 
-# # The hatch docker image is built with the tools/cicd/cloudbuild.yaml build.
-# - name: us-docker.pkg.dev/$PROJECT_ID/tools/hatch:${_PYTHON_VERSION}
-#   id: tests
-#   dir: $_GITHUB_REPOSITORY
-#   args:
-#   - test
+# The hatch docker image is built with the tools/cicd/cloudbuild.yaml build.
+- name: us-docker.pkg.dev/$PROJECT_ID/tools/hatch:${_PYTHON_VERSION}
+  id: tests
+  dir: $_GITHUB_REPOSITORY
+  args:
+  - test
 
-# - name: us-docker.pkg.dev/$PROJECT_ID/tools/hatch:${_PYTHON_VERSION}
-#   id: lint
-#   dir: $_GITHUB_REPOSITORY
-#   args:
-#   - run
-#   - lint:all
+- name: us-docker.pkg.dev/$PROJECT_ID/tools/hatch:${_PYTHON_VERSION}
+  id: lint
+  dir: $_GITHUB_REPOSITORY
+  args:
+  - run
+  - lint:all
 
-# - name: us-docker.pkg.dev/$PROJECT_ID/tools/hatch:${_PYTHON_VERSION}
-#   id: build
-#   dir: $_GITHUB_REPOSITORY
-#   args:
-#   - build
+- name: us-docker.pkg.dev/$PROJECT_ID/tools/hatch:${_PYTHON_VERSION}
+  id: build
+  dir: $_GITHUB_REPOSITORY
+  args:
+  - build
 
-# # Create a release on GitHub.
-# # The `hub` image has been built previously in the project:
-# # $ git clone https://github.com/GoogleCloudPlatform/cloud-builders-community.git
-# # $ cd cloud-builders-community/hub
-# # $ gcloud builds submit
-# - name: 'us-docker.pkg.dev/$PROJECT_ID/tools/hub'
-#   id: 'release'
-#   dir: $_GITHUB_REPOSITORY
-#   entrypoint: 'bash'
-#   args:
-#   - '-c'
-#   - |
-#     export GITHUB_TOKEN=$(</root/github_token)
-#     hub release create -m "release v$_NEW_VERSION" "v$_NEW_VERSION"
-#   env:
-#   - GITHUB_USER=kaggle
-#   - GITHUB_REPOSITORY=$_GITHUB_REPOSITORY
-#   - HUB_PROTOCOL=https
-#   volumes:
-#   - name: 'root'
-#     path: /root
+# Create a release on GitHub.
+# The `hub` image has been built previously in the project:
+# $ git clone https://github.com/GoogleCloudPlatform/cloud-builders-community.git
+# $ cd cloud-builders-community/hub
+# $ gcloud builds submit
+- name: 'us-docker.pkg.dev/$PROJECT_ID/tools/hub'
+  id: 'release'
+  dir: $_GITHUB_REPOSITORY
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    export GITHUB_TOKEN=$(</root/github_token)
+    hub release create -m "release v$_NEW_VERSION" "v$_NEW_VERSION"
+  env:
+  - GITHUB_USER=kaggle
+  - GITHUB_REPOSITORY=$_GITHUB_REPOSITORY
+  - HUB_PROTOCOL=https
+  volumes:
+  - name: 'root'
+    path: /root
 
-# # Release package to pypi.
-# - name: us-docker.pkg.dev/$PROJECT_ID/tools/hatch:${_PYTHON_VERSION}
-#   id: release-pypi
-#   dir: $_GITHUB_REPOSITORY
-#   entrypoint: bash 
-#   args:
-#   - '-c'
-#   - |
-#     twine upload dist/* -r pypi
-#   volumes:
-#   - name: 'root'
-#     path: /root
+# Release package to pypi.
+- name: us-docker.pkg.dev/$PROJECT_ID/tools/hatch:${_PYTHON_VERSION}
+  id: release-pypi
+  dir: $_GITHUB_REPOSITORY
+  entrypoint: bash 
+  args:
+  - '-c'
+  - |
+    twine upload dist/* -r pypi
+  volumes:
+  - name: 'root'
+    path: /root
 
 substitutions:
   _GITHUB_REPOSITORY: kagglehub


### PR DESCRIPTION
* Pin the hatch version on cicd & release process to avoid issues like: https://chat.kaggle.net/kaggle/pl/88k9ymee8pn5fb83ruyceiyxbh