### PR TITLE
Use version number in notebook cache directories

### DIFF
--- a/integration_tests/test_notebook_output_download.py
+++ b/integration_tests/test_notebook_output_download.py
@@ -20,15 +20,25 @@ class TestModelDownload(unittest.TestCase):
 
     def test_download_notebook_versioned_output_succeeds(self) -> None:
         with create_test_cache():
-            actual_path = notebook_output_download("alexisbcook/titanic-tutorial/versions/1")
+            actual_path = notebook_output_download(VERSIONED_NOTEBOOK_HANDLE)
 
-            expected_file = ["my_submission.csv"]
-            assert_files(self, actual_path, expected_file)
+            expected_files = ["my_submission.csv"]
+            assert_files(self, actual_path, expected_files)
+
+    def test_download_both_notebook_outputs_succeeds(self) -> None:
+        with create_test_cache():
+            versioned_path = notebook_output_download(VERSIONED_NOTEBOOK_HANDLE)
+            unversioned_path = notebook_output_download(UNVERSIONED_NOTEBOOK_HANDLE)
+
+            expected_versioned_files = ["my_submission.csv"]
+            expected_unversioned_files = ["submission.csv"]
+            assert_files(self, versioned_path, expected_versioned_files)
+            assert_files(self, unversioned_path, expected_unversioned_files)
 
     def test_download_public_notebook_output_as_unauthenticated_succeeds(self) -> None:
         with create_test_cache():
             with unauthenticated():
-                actual_path = notebook_output_download("alexisbcook/titanic-tutorial")
+                actual_path = notebook_output_download(UNVERSIONED_NOTEBOOK_HANDLE)
 
                 expected_files = ["submission.csv"]
                 assert_files(self, actual_path, expected_files)

--- a/src/kagglehub/cache.py
+++ b/src/kagglehub/cache.py
@@ -103,7 +103,6 @@ def delete_from_cache(handle: ResourceHandle, path: Optional[str] = None) -> Opt
 
 
 def _get_completion_marker_filepath(handle: ResourceHandle, path: Optional[str] = None) -> str:
-    # Can extend to add support for other resources like DatasetHandle.
     if isinstance(handle, ModelHandle):
         return _get_models_completion_marker_filepath(handle, path)
     elif isinstance(handle, DatasetHandle):
@@ -127,6 +126,9 @@ def _get_dataset_path(handle: DatasetHandle, path: Optional[str] = None) -> str:
 
 def _get_notebook_output_path(handle: NotebookHandle, path: Optional[str] = None) -> str:
     base_path = os.path.join(get_cache_folder(), NOTEBOOKS_CACHE_SUBFOLDER, handle.owner, handle.notebook, "output")
+    if handle.is_versioned():
+        base_path = os.path.join(base_path, "versions", str(handle.version))
+
     return os.path.join(base_path, path) if path else base_path
 
 
@@ -180,7 +182,13 @@ def _get_competition_archive_path(handle: CompetitionHandle) -> str:
 
 
 def _get_notebook_output_archive_path(handle: NotebookHandle) -> str:
-    return os.path.join(get_cache_folder(), NOTEBOOKS_CACHE_SUBFOLDER, handle.owner, handle.notebook, "output.archive")
+    return os.path.join(
+        get_cache_folder(),
+        NOTEBOOKS_CACHE_SUBFOLDER,
+        handle.owner,
+        handle.notebook,
+        "output-{handle.version!s}.archive",
+    )
 
 
 def _get_models_completion_marker_filepath(handle: ModelHandle, path: Optional[str] = None) -> str:
@@ -237,10 +245,17 @@ def _get_notebook_output_completion_marker_filepath(handle: NotebookHandle, path
             handle.owner,
             handle.notebook,
             FILE_COMPLETION_MARKER_FOLDER,
-            "output",
+            f"output-{handle.version!s}",
             f"{path}.complete",
         )
-    return os.path.join(get_cache_folder(), NOTEBOOKS_CACHE_SUBFOLDER, handle.owner, handle.notebook, "output.complete")
+
+    return os.path.join(
+        get_cache_folder(),
+        NOTEBOOKS_CACHE_SUBFOLDER,
+        handle.owner,
+        handle.notebook,
+        "output-{handle.version!s}.complete",
+    )
 
 
 def _get_competitions_completion_marker_filepath(handle: CompetitionHandle, path: Optional[str] = None) -> str:

--- a/src/kagglehub/http_resolver.py
+++ b/src/kagglehub/http_resolver.py
@@ -206,10 +206,10 @@ class NotebookOutputHttpResolver(Resolver[NotebookHandle]):
         if not h.is_versioned():
             h.version = _get_current_version(api_client, h)
 
-        nb_path = load_from_cache(h, path)
-        if nb_path and not force_download:
-            return nb_path  # Already cached
-        elif nb_path and force_download:
+        notebook_path = load_from_cache(h, path)
+        if notebook_path and not force_download:
+            return notebook_path  # Already cached
+        elif notebook_path and force_download:
             delete_from_cache(h, path)
 
         url_path = _build_notebook_download_url_path(h, path)
@@ -314,6 +314,10 @@ def _build_get_instance_url_path(h: ModelHandle) -> str:
 
 
 def _build_model_download_url_path(h: ModelHandle, path: Optional[str]) -> str:
+    if not h.is_versioned():
+        msg = "No version provided"
+        raise ValueError(msg)
+
     base_url = f"models/{h.owner}/{h.model}/{h.framework}/{h.variation}/{h.version}/download"
     if path:
         return f"{base_url}/{path}"
@@ -322,6 +326,10 @@ def _build_model_download_url_path(h: ModelHandle, path: Optional[str]) -> str:
 
 
 def _build_list_model_instance_version_files_url_path(h: ModelHandle) -> str:
+    if not h.is_versioned():
+        msg = "No version provided"
+        raise ValueError(msg)
+
     return f"models/{h.owner}/{h.model}/{h.framework}/{h.variation}/{h.version}/files\
 ?page_size={MAX_NUM_FILES_DIRECT_DOWNLOAD}"
 

--- a/tests/test_http_notebook_output_download.py
+++ b/tests/test_http_notebook_output_download.py
@@ -18,7 +18,7 @@ TEST_CONTENTS = "foo"
 
 
 EXPECTED_NOTEBOOK_SUBDIR = os.path.join(
-    NOTEBOOKS_CACHE_SUBFOLDER, "khsamaha", "simple-lightgbm-kaggle-sticker-sales-py", "output"
+    NOTEBOOKS_CACHE_SUBFOLDER, "khsamaha", "simple-lightgbm-kaggle-sticker-sales-py", "output", "versions", "2"
 )
 
 


### PR DESCRIPTION
Despite the fact that neither Datasets nor Notebooks datasources currently support multi-versioning when attached to a Kaggle Notebook Session, our existing Dataset support in HTTP resolving *does* use a cache dir with the version number so that multiple versions are supported in that mode.  Here we update the recent Notebook support to match that behavior.

Some minor tangentially related cleanup for consistency reasons too.

http://b/384702998