### PR TITLE
Improve typing for MultiImplRegistry

### DIFF
--- a/src/kagglehub/registry.py
+++ b/src/kagglehub/registry.py
@@ -1,7 +1,12 @@
-from typing import Callable
+from typing import Generic, TypeVar
+
+from kagglehub.handle import CompetitionHandle, DatasetHandle, ModelHandle, NotebookHandle, ResourceHandle
+from kagglehub.resolver import Resolver
+
+T = TypeVar("T", bound=ResourceHandle)
 
 
-class MultiImplRegistry:
+class MultiImplRegistry(Generic[T]):
     """Utility class to inject multiple implementations of class.
 
     Each implementation must implement __call__ and is_supported with the same set of arguments. The registered
@@ -11,12 +16,12 @@ class MultiImplRegistry:
 
     def __init__(self, name: str) -> None:
         self._name = name
-        self._impls: list[Callable] = []
+        self._impls: list[Resolver[T]] = []
 
-    def add_implementation(self, impl: Callable) -> None:
-        self._impls += [impl]
+    def add_implementation(self, impl: Resolver[T]) -> None:
+        self._impls.append(impl)
 
-    def __call__(self, *args, **kwargs):  # noqa: ANN002, ANN003
+    def __call__(self, *args, **kwargs) -> str:  # noqa: ANN002, ANN003
         fails = []
         for impl in reversed(self._impls):
             if impl.is_supported(*args, **kwargs):
@@ -28,7 +33,7 @@ class MultiImplRegistry:
         raise RuntimeError(msg)
 
 
-model_resolver = MultiImplRegistry("ModelResolver")
-dataset_resolver = MultiImplRegistry("DatasetResolver")
-competition_resolver = MultiImplRegistry("CompetitionResolver")
-notebook_output_resolver = MultiImplRegistry("NotebookOutputResolver")
+model_resolver = MultiImplRegistry[ModelHandle]("ModelResolver")
+dataset_resolver = MultiImplRegistry[DatasetHandle]("DatasetResolver")
+competition_resolver = MultiImplRegistry[CompetitionHandle]("CompetitionResolver")
+notebook_output_resolver = MultiImplRegistry[NotebookHandle]("NotebookOutputResolver")

--- a/src/kagglehub/resolver.py
+++ b/src/kagglehub/resolver.py
@@ -10,7 +10,7 @@ class Resolver(Generic[T]):
     __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
-    def __call__(self, handle: T, path: Optional[str], *, force_download: Optional[bool] = False) -> str:
+    def __call__(self, handle: T, path: Optional[str] = None, *, force_download: Optional[bool] = False) -> str:
         """Resolves a handle into a path with the requested model files.
 
         Args:
@@ -25,6 +25,6 @@ class Resolver(Generic[T]):
         pass
 
     @abc.abstractmethod
-    def is_supported(self, handle: T, path: Optional[str]) -> bool:
+    def is_supported(self, handle: T, path: Optional[str] = None) -> bool:
         """Returns whether the current environment supports this handle/path."""
         pass

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,49 +1,60 @@
 from typing import Any, Callable
 
 from kagglehub import registry
+from kagglehub.handle import ResourceHandle
+from kagglehub.resolver import Resolver
 from tests.fixtures import BaseTestCase
 
-SOME_VALUE = 1
+SOME_VALUE: str = "test"
 
 
-def fail_fn(_) -> None:  # noqa: ANN001
-    msg = "fail_fn should not be callted"
-    raise AssertionError(msg)
+class FakeHandle(ResourceHandle):
+    def to_url(self) -> str:
+        raise NotImplementedError()
 
 
-class FakeImpl:
-    def __init__(self, is_supported_fn: Callable[..., bool], call_fn: Callable[..., Any]) -> None:
+class FakeImpl(Resolver[FakeHandle]):
+    def __init__(
+        self,
+        is_supported_fn: Callable[[FakeHandle], bool],
+        call_fn: Callable[[FakeHandle], str],
+    ):
         self._is_supported_fn = is_supported_fn
         self._call_fn = call_fn
 
     def is_supported(self, *args: Any, **kwargs: Any) -> bool:  # noqa: ANN401
         return self._is_supported_fn(*args, **kwargs)
 
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+    def __call__(self, *args: Any, **kwargs: Any) -> str:  # noqa: ANN401
         return self._call_fn(*args, **kwargs)
+
+
+def fail_fn(*_, **__) -> str:  # noqa: ANN002, ANN003
+    msg = "fail_fn should not be called"
+    raise AssertionError(msg)
 
 
 class RegistryTest(BaseTestCase):
     def test_calls_only_supported(self) -> None:
-        r = registry.MultiImplRegistry("test")
-        r.add_implementation(FakeImpl(lambda _: True, lambda _: SOME_VALUE))
-        r.add_implementation(FakeImpl(lambda _: False, fail_fn))
+        r = registry.MultiImplRegistry[FakeHandle]("test")
+        r.add_implementation(FakeImpl(lambda *_, **__: True, lambda *_, **__: SOME_VALUE))
+        r.add_implementation(FakeImpl(lambda *_, **__: False, fail_fn))
 
-        val = r(SOME_VALUE)
+        val = r(FakeHandle())
 
         self.assertEqual(SOME_VALUE, val)
 
     def test_calls_first_supported_reverse(self) -> None:
-        r = registry.MultiImplRegistry("test")
-        r.add_implementation(FakeImpl(lambda _: True, fail_fn))
-        r.add_implementation(FakeImpl(lambda _: True, lambda _: SOME_VALUE))
+        r = registry.MultiImplRegistry[FakeHandle]("test")
+        r.add_implementation(FakeImpl(lambda *_, **__: True, fail_fn))
+        r.add_implementation(FakeImpl(lambda *_, **__: True, lambda *_, **__: SOME_VALUE))
 
-        val = r(SOME_VALUE)
+        val = r(FakeHandle())
 
         self.assertEqual(SOME_VALUE, val)
 
     def test_calls_throw_not_supported(self) -> None:
-        r = registry.MultiImplRegistry("test")
-        r.add_implementation(FakeImpl(lambda _: False, fail_fn))
+        r = registry.MultiImplRegistry[FakeHandle]("test")
+        r.add_implementation(FakeImpl(lambda *_, **__: False, fail_fn))
 
         self.assertRaisesRegex(RuntimeError, r"Missing implementation", r, SOME_VALUE)


### PR DESCRIPTION
This proved useful for upcoming Package support, but also feels like a nice change on its own, and thought it should be pulled out to its own PR.

I considered also added a second generic type `U` for the return type (currently `str` but intending to expand to a `tuple` for Packages) but not sure it's worthwhile since we currently have and expect to maintain conformity there anyway.