### PR TITLE
Ask user confirmation before import in `package_import`

### DIFF
--- a/integration_tests/test_package_import.py
+++ b/integration_tests/test_package_import.py
@@ -1,47 +1,75 @@
 import sys
 import unittest
+from unittest import mock
 
 from kagglehub import package_import
+from kagglehub.exceptions import UserCancelledError
 
-from .utils import create_test_cache, unauthenticated
+from .utils import create_test_cache, parameterized, unauthenticated
 
 UNVERSIONED_HANDLE = "dster/package-test"
 VERSIONED_HANDLE = "dster/package-test/versions/1"
+
+YES_INPUTS = ["yes", "y", "YES", "Y", "YeS"]
 
 
 class TestPackageImport(unittest.TestCase):
 
     def tearDown(self) -> None:
-        # Clear any imported packages from sys.modules.
-        for name in list(sys.modules.keys()):
-            if name.startswith("kagglehub_package"):
-                del sys.modules[name]
+        names = [name for name in sys.modules if name.startswith("kagglehub_package")]
+        for name in names:
+            del sys.modules[name]
 
-    def test_package_versioned_succeeds(self) -> None:
+    @parameterized(*YES_INPUTS)
+    def test_package_versioned_succeeds(self, input_value: str) -> None:
+        with mock.patch("builtins.input", return_value=input_value) as mock_input:
+            with create_test_cache():
+                package = package_import(VERSIONED_HANDLE)
+
+                mock_input.assert_called_once()
+                self.assertIn("foo", dir(package))
+                self.assertEqual("bar", package.foo())
+
+    def test_package_versioned_bypass_confirmation_succeeds(self) -> None:
         with create_test_cache():
-            package = package_import(VERSIONED_HANDLE)
+            package = package_import(VERSIONED_HANDLE, bypass_confirmation=True)
 
             self.assertIn("foo", dir(package))
             self.assertEqual("bar", package.foo())
 
-    def test_package_unversioned_succeeds(self) -> None:
-        with create_test_cache():
-            package = package_import(UNVERSIONED_HANDLE)
+    @parameterized(*YES_INPUTS)
+    def test_package_unversioned_succeeds(self, input_value: str) -> None:
+        with mock.patch("builtins.input", return_value=input_value) as mock_input:
+            with create_test_cache():
+                package = package_import(UNVERSIONED_HANDLE)
 
-            self.assertIn("foo", dir(package))
-            self.assertEqual("baz", package.foo())
+                mock_input.assert_called_once()
+                self.assertIn("foo", dir(package))
+                self.assertEqual("baz", package.foo())
 
     def test_download_private_package_succeeds(self) -> None:
+        # Don't require confirmation since we're running as integrationtester.
         with create_test_cache():
             package = package_import("integrationtester/kagglehub-test-private-package")
 
             self.assertIn("foo", dir(package))
             self.assertEqual("bar", package.foo())
 
-    def test_public_package_with_unauthenticated_succeeds(self) -> None:
-        with create_test_cache():
-            with unauthenticated():
-                package = package_import(UNVERSIONED_HANDLE)
+    @parameterized(*YES_INPUTS)
+    def test_public_package_with_unauthenticated_succeeds(self, input_value: str) -> None:
+        with mock.patch("builtins.input", return_value=input_value) as mock_input:
+            with create_test_cache():
+                with unauthenticated():
+                    package = package_import(UNVERSIONED_HANDLE)
 
-                self.assertIn("foo", dir(package))
-                self.assertEqual("baz", package.foo())
+                    mock_input.assert_called_once()
+                    self.assertIn("foo", dir(package))
+                    self.assertEqual("baz", package.foo())
+
+    @parameterized("no", "NO", "n", "", "anything but yes")
+    def test_package_versioned_aborts(self, input_value: str) -> None:
+        with mock.patch("builtins.input", return_value=input_value) as mock_input:
+            with create_test_cache():
+                with self.assertRaises(UserCancelledError):
+                    package_import(VERSIONED_HANDLE)
+                mock_input.assert_called_once()

--- a/src/kagglehub/auth.py
+++ b/src/kagglehub/auth.py
@@ -114,17 +114,19 @@ def _notebook_login(validate_credentials: bool) -> None:  # noqa: FBT001
     login_button.on_click(on_click_login_button)
 
 
-def _validate_credentials_helper() -> Optional[str]:
+def _validate_credentials_helper(*, verbose: bool = True) -> Optional[str]:
     api_client = KaggleApiV1Client()
     response = api_client.get("/hello")
     if "userName" in response:
-        _logger.info("Kaggle credentials successfully validated.")
+        if verbose:
+            _logger.info("Kaggle credentials successfully validated.")
         return response["userName"]
     elif "code" in response and response["code"] == INVALID_CREDENTIALS_ERROR:
-        _logger.error(
-            "Invalid Kaggle credentials. You can check your credentials on the [Kaggle settings page](https://www.kaggle.com/settings/account)."
-        )
-    else:
+        if verbose:
+            _logger.error(
+                "Invalid Kaggle credentials. You can check your credentials on the [Kaggle settings page](https://www.kaggle.com/settings/account)."
+            )
+    elif verbose:
         _logger.warning("Unable to validate Kaggle credentials at this time.")
     return None
 
@@ -161,3 +163,11 @@ def whoami() -> dict:
         raise UnauthenticatedError()
     except Exception as e:
         raise UnauthenticatedError() from e
+
+
+def get_username() -> Optional[str]:
+    """Returns the username of the authenticated logged-in user if configured, otherwise None."""
+    try:
+        return _validate_credentials_helper(verbose=False)
+    except Exception:
+        return None

--- a/src/kagglehub/exceptions.py
+++ b/src/kagglehub/exceptions.py
@@ -53,6 +53,10 @@ class UnauthenticatedError(Exception):
         super().__init__(message)
 
 
+class UserCancelledError(Exception):
+    pass
+
+
 def kaggle_api_raise_for_status(response: requests.Response, resource_handle: Optional[ResourceHandle] = None) -> None:
     """
     Wrapper around `response.raise_for_status()` that provides nicer error messages

--- a/src/kagglehub/handle.py
+++ b/src/kagglehub/handle.py
@@ -126,7 +126,10 @@ class UtilityScriptHandle(NotebookHandle):
 
 
 class PackageHandle(NotebookHandle):
-    pass
+    def with_version(self, version: int) -> "PackageHandle":
+        kwargs = asdict(self)
+        kwargs["version"] = version
+        return PackageHandle(**kwargs)
 
 
 def parse_dataset_handle(handle: str) -> DatasetHandle:

--- a/tests/server_stubs/notebook_output_download_stub.py
+++ b/tests/server_stubs/notebook_output_download_stub.py
@@ -11,6 +11,9 @@ from tests.utils import (
 app = Flask(__name__)
 add_mock_gcs_route(app)
 
+GOOD_CREDENTIALS_USERNAME = "dster"
+GOOD_CREDENTIALS_API_KEY = "some-key"
+
 # See https://cloud.google.com/storage/docs/xml-api/reference-headers#xgooghash
 GCS_HASH_HEADER = "x-goog-hash"
 LAST_MODIFIED = "Last-Modified"
@@ -20,6 +23,16 @@ LAST_MODIFIED_DATE = "Thu, 02 Mar 2020 02:17:12 GMT"
 @app.route("/", methods=["HEAD"])
 def head() -> ResponseReturnValue:
     return "", 200
+
+
+@app.route("/api/v1/hello", methods=["GET"])
+def model_create() -> ResponseReturnValue:
+    auth = request.authorization
+    if auth and auth.username == GOOD_CREDENTIALS_USERNAME and auth.password == GOOD_CREDENTIALS_API_KEY:
+        data = {"message": "Hello from test server!", "userName": auth.username}
+        return jsonify(data), 200
+    else:
+        return jsonify({"code": 401}), 200
 
 
 @app.route("/api/v1/kernels/pull", methods=["GET"])

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,5 @@
 import io
 import logging
-from unittest import mock
 
 import kagglehub
 from kagglehub.auth import _capture_logger_output
@@ -8,6 +7,7 @@ from kagglehub.auth import _logger as logger
 from kagglehub.config import get_kaggle_credentials
 from kagglehub.exceptions import UnauthenticatedError
 from tests.fixtures import BaseTestCase
+from tests.utils import login
 
 from .server_stubs import auth_stub as stub
 from .server_stubs import serv
@@ -82,11 +82,3 @@ class TestAuth(BaseTestCase):
 
         result = kagglehub.whoami()
         self.assertEqual(result, {"username": "lastplacelarry"})
-
-
-def login(username: str, api_key: str, validate_credentials: bool = True) -> None:  # noqa: FBT002, FBT001
-    with mock.patch("builtins.input") as mock_input:
-        with mock.patch("getpass.getpass") as mock_getpass:
-            mock_input.side_effect = [username]
-            mock_getpass.return_value = api_key
-            kagglehub.login(validate_credentials=validate_credentials)

--- a/tests/test_http_package_import.py
+++ b/tests/test_http_package_import.py
@@ -1,14 +1,15 @@
 import os
-import sys
+from unittest import mock
 
 import kagglehub
 from kagglehub.cache import NOTEBOOKS_CACHE_SUBFOLDER, get_cached_archive_path
+from kagglehub.exceptions import UserCancelledError
 from kagglehub.handle import parse_package_handle
 from tests.fixtures import BaseTestCase
 
 from .server_stubs import notebook_output_download_stub as stub
 from .server_stubs import serv
-from .utils import create_test_cache
+from .utils import clear_imported_kaggle_packages, create_test_cache, login, parameterized
 
 INVALID_ARCHIVE_PACKAGE_HANDLE = "invalid/invalid/invalid/invalid/invalid"
 VERSIONED_PACKAGE_HANDLE = "dster/package-test/versions/1"
@@ -16,14 +17,13 @@ UNVERSIONED_PACKAGE_HANDLE = "dster/package-test"
 
 EXPECTED_NOTEBOOK_SUBDIR = os.path.join(NOTEBOOKS_CACHE_SUBFOLDER, "dster", "package-test", "output", "versions", "1")
 
+YES_INPUTS = ["yes", "y", "YES", "Y", "YeS"]
+
 
 class TestHttpPackageImport(BaseTestCase):
 
     def tearDown(self) -> None:
-        # Clear any imported packages from sys.modules.
-        for name in list(sys.modules.keys()):
-            if name.startswith("kagglehub_package"):
-                del sys.modules[name]
+        clear_imported_kaggle_packages()
 
     @classmethod
     def setUpClass(cls):
@@ -33,9 +33,22 @@ class TestHttpPackageImport(BaseTestCase):
     def tearDownClass(cls):
         cls.server.shutdown()
 
-    def test_package_versioned_succeeds(self) -> None:
+    @parameterized(*YES_INPUTS)
+    def test_package_versioned_succeeds(self, input_value: str) -> None:
+        with mock.patch("builtins.input", return_value=input_value) as mock_input:
+            with create_test_cache():
+                package = kagglehub.package_import(VERSIONED_PACKAGE_HANDLE)
+
+                mock_input.assert_called_once()
+                self.assertIn("foo", dir(package))
+                self.assertEqual("bar", package.foo())
+
+                archive_path = get_cached_archive_path(parse_package_handle(VERSIONED_PACKAGE_HANDLE))
+                self.assertFalse(os.path.exists(archive_path))
+
+    def test_package_versioned_bypass_confirmation_succeeds(self) -> None:
         with create_test_cache():
-            package = kagglehub.package_import(VERSIONED_PACKAGE_HANDLE)
+            package = kagglehub.package_import(VERSIONED_PACKAGE_HANDLE, bypass_confirmation=True)
 
             self.assertIn("foo", dir(package))
             self.assertEqual("bar", package.foo())
@@ -43,15 +56,38 @@ class TestHttpPackageImport(BaseTestCase):
             archive_path = get_cached_archive_path(parse_package_handle(VERSIONED_PACKAGE_HANDLE))
             self.assertFalse(os.path.exists(archive_path))
 
-    def test_package_unversioned_succeeds(self) -> None:
+    def test_package_versioned_user_owned_succeeds(self) -> None:
+        login("dster", "some-key")
+
         with create_test_cache():
-            package = kagglehub.package_import(UNVERSIONED_PACKAGE_HANDLE)
+            package = kagglehub.package_import(VERSIONED_PACKAGE_HANDLE, bypass_confirmation=True)
 
             self.assertIn("foo", dir(package))
-            self.assertEqual("baz", package.foo())
+            self.assertEqual("bar", package.foo())
 
-            archive_path = get_cached_archive_path(parse_package_handle(UNVERSIONED_PACKAGE_HANDLE))
+            archive_path = get_cached_archive_path(parse_package_handle(VERSIONED_PACKAGE_HANDLE))
             self.assertFalse(os.path.exists(archive_path))
+
+    @parameterized(*YES_INPUTS)
+    def test_package_unversioned_succeeds(self, input_value: str) -> None:
+        with mock.patch("builtins.input", return_value=input_value) as mock_input:
+            with create_test_cache():
+                package = kagglehub.package_import(UNVERSIONED_PACKAGE_HANDLE)
+
+                mock_input.assert_called_once()
+                self.assertIn("foo", dir(package))
+                self.assertEqual("baz", package.foo())
+
+                archive_path = get_cached_archive_path(parse_package_handle(UNVERSIONED_PACKAGE_HANDLE))
+                self.assertFalse(os.path.exists(archive_path))
+
+    @parameterized("no", "NO", "n", "", "anything but yes")
+    def test_package_versioned_aborts(self, input_value: str) -> None:
+        with mock.patch("builtins.input", return_value=input_value) as mock_input:
+            with create_test_cache():
+                with self.assertRaises(UserCancelledError):
+                    kagglehub.package_import(VERSIONED_PACKAGE_HANDLE)
+                mock_input.assert_called_once()
 
     def test_notebook_download_bad_archive(self) -> None:
         with create_test_cache():

--- a/tests/test_kaggle_cache_package_import.py
+++ b/tests/test_kaggle_cache_package_import.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from unittest import mock
 
 import requests
@@ -8,6 +7,7 @@ import kagglehub
 from kagglehub.config import DISABLE_KAGGLE_CACHE_ENV_VAR_NAME
 from kagglehub.env import KAGGLE_DATA_PROXY_URL_ENV_VAR_NAME
 from tests.fixtures import BaseTestCase
+from tests.utils import clear_imported_kaggle_packages
 
 from .server_stubs import jwt_stub as stub
 from .server_stubs import serv
@@ -21,10 +21,7 @@ UNVERSIONED_PACKAGE_HANDLE = "alexisbcook/test-package"
 class TestKaggleCachePackageImport(BaseTestCase):
 
     def tearDown(self) -> None:
-        # Clear any imported packages from sys.modules.
-        for name in list(sys.modules.keys()):
-            if name.startswith("kagglehub_package"):
-                del sys.modules[name]
+        clear_imported_kaggle_packages()
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Importing a python package involves running (some of) the code defined within it, and running untrusted code on an insecure environment can be dangerous. Let's warn the user and get explicit confirmation in such cases. We skip the checks within Kaggle or Colab Notebooks, when the logged-in user is the author, and for nested Kaggle Packages.

NOTE: This is just merging into the WIP `packages` branch.

http://b/393606413