### PR TITLE
Fix invalid example terminal code in integration_tests readme

### DIFF
--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -6,8 +6,8 @@ who are creating or updating tests and want to run locally.
 Integration tests should be run by the `integrationtester` Kaggle account. Make
 sure you have configured your local `kagglehub` accordingly, via
 ```
-EXPORT KAGGLE_USERNAME=integrationtester
-EXPORT KAGGLE_KEY=...
+export KAGGLE_USERNAME=integrationtester
+export KAGGLE_KEY=...
 ```
 Visit [go/kaggle-integrationtester](http://go/kaggle-integrationtester) to get
 the correct `KAGGLE_KEY` value to use in the above command (Actions -> Get


### PR DESCRIPTION
Rename `EXPORT` to `export`