### PR TITLE
Move signing to optional module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next Release
 
-* 
+* Moved signing as optional feature due to dependency issue.
 
 ## v0.3.7 (January 31, 2025)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
   "requests", 
   "tqdm",
   "packaging",
-  "model_signing",
 ]
 
 [project.urls]
@@ -34,7 +33,7 @@ dependencies = [
 [project.optional-dependencies]
 hf-datasets = ["datasets", "kagglehub[pandas-datasets]"]
 pandas-datasets = ["pandas"]
-
+signing = [ "model_signing", "sigstore>=3.6.1", "betterproto>=2.0.0b6"]
 
 # twine 6.0.1 doesn't support metadata-version 2.4.
 # remove `core-metadata-version` pin once twine release a new version with: https://github.com/pypa/twine/pull/1180
@@ -57,8 +56,7 @@ dependencies = [
   "openpyxl",
   "pyjwt[crypto]",
 ]
-features = ["hf-datasets"]
-installer = "pip"
+features = ["hf-datasets", "signing"]
 
 [[tool.hatch.envs.hatch-test.matrix]]
 python = ["3.9", "3.10", "3.11", "3.12"]
@@ -116,6 +114,14 @@ dependencies = [
 ]
 features = [
   "pandas-datasets",
+]
+
+# Signing is unable to be installed via uv without a prerelease library: b/395859806
+[tool.hatch.envs.signing]
+dependencies = [
+]
+features = [
+  "signing",
 ]
 
 [tool.black]

--- a/src/kagglehub/models.py
+++ b/src/kagglehub/models.py
@@ -5,7 +5,7 @@ from kagglehub import registry
 from kagglehub.gcs_upload import normalize_patterns, upload_files_and_directories
 from kagglehub.handle import parse_model_handle
 from kagglehub.logger import EXTRA_CONSOLE_BLOCK
-from kagglehub.models_helpers import create_model_if_missing, create_model_instance_or_version, signing_token
+from kagglehub.models_helpers import create_model_if_missing, create_model_instance_or_version
 from kagglehub.signing import sign_with_sigstore
 
 logger = logging.getLogger(__name__)

--- a/src/kagglehub/signing.py
+++ b/src/kagglehub/signing.py
@@ -1,0 +1,31 @@
+import logging
+from pathlib import Path
+
+from kagglehub.handle import ModelHandle
+from kagglehub.models_helpers import signing_token
+
+logger = logging.getLogger(__name__)
+
+
+def sign_with_sigstore(local_model_dir: str, handle: ModelHandle) -> bool:
+    from model_signing.api import SigningConfig
+
+    try:
+        token = signing_token(handle.owner, handle.model)
+        if token:
+            signing_file = Path(local_model_dir) / ".kaggle" / "signing.json"
+            signing_file.parent.mkdir(exist_ok=True, parents=True)
+            signing_file.unlink(missing_ok=True)
+            # The below will throw an exception if the token can't be verified (Needs to be a production token)
+            # Setting KAGGLE_API_ENDPOINT to localhost will throw the exception as stated above.
+            SigningConfig().set_sigstore_signer(identity_token=token, use_staging=False).sign(
+                Path(local_model_dir), signing_file
+            )
+            return True
+        else:
+            # skips transparency log publishing as we are unable to get a token
+            logger.warning("Unable to retrieve identity token. Skipping signing...")
+            return False
+    except Exception:
+        logger.exception("Signing failed. Skipping signing...")
+        return False


### PR DESCRIPTION
* Temp fixed uv issue for hatch test by adding direct  dependencies
* Users will be notified to install optional dependencies when using `sign=True`

See b/395859806 and https://github.com/Kaggle/kagglehub/issues/224