### PR TITLE
Change colab environment detection logic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ## Next Release
 
+* Fix Colab environment detection logic ([#230](https://github.com/Kaggle/kagglehub/pull/230))
+
 ## v0.3.9 (February 18, 2025)
 
-* Renamed load_datset to dataset_load.
+* Renamed load_datset to dataset_load ([#228](https://github.com/Kaggle/kagglehub/pull/228))
 
 ## v0.3.8 (February 13, 2025)
 
-* Moved signing as optional feature due to dependency issue.
+* Moved signing as optional feature due to dependency issue ([#225](https://github.com/Kaggle/kagglehub/pull/225))
 
 ## v0.3.7 (January 31, 2025)
 

--- a/src/kagglehub/config.py
+++ b/src/kagglehub/config.py
@@ -163,7 +163,6 @@ def get_colab_credentials() -> Optional[KaggleApiCredentials]:
     # userdata access is already thread-safe after b/318732641
     try:
         from google.colab import userdata  # type: ignore[import]
-        from google.colab.errors import Error as ColabError  # type: ignore[import]
     except ImportError:
         return None
 
@@ -172,6 +171,7 @@ def get_colab_credentials() -> Optional[KaggleApiCredentials]:
         key = _normalize_whitespace(userdata.get(COLAB_SECRET_KEY))
         if username and key:
             return KaggleApiCredentials(username=username, key=key)
-    except ColabError:
-        pass
-    return None
+        return None
+    except Exception:
+        # fail to get Kaggle credentials from Colab secrets. Skip...
+        return None

--- a/src/kagglehub/env.py
+++ b/src/kagglehub/env.py
@@ -11,9 +11,18 @@ KAGGLE_TOKEN_KEY_DIR_ENV_VAR_NAME = "KAGGLE_API_V1_TOKEN"
 
 logger = logging.getLogger(__name__)
 
+try:
+    from IPython import get_ipython  # type: ignore
+
+    # Set to `True` if script is running in a Google Colab notebook.
+    # Taken from https://stackoverflow.com/a/63519730.
+    _is_google_colab = "google.colab" in str(get_ipython())
+except (NameError, ModuleNotFoundError):
+    _is_google_colab = False
+
 
 def is_in_colab_notebook() -> bool:
-    return os.getenv("COLAB_RELEASE_TAG") is not None
+    return _is_google_colab
 
 
 def is_in_kaggle_notebook() -> bool:

--- a/tests/test_kaggle_api_client.py
+++ b/tests/test_kaggle_api_client.py
@@ -96,6 +96,7 @@ class TestKaggleApiV1Client(BaseTestCase):
             "COLAB_RELEASE_TAG": "release-colab-20230531-060125-RC00",
         },
     )
+    @patch("kagglehub.env._is_google_colab", True)
     def test_get_user_agent_colab(self) -> None:
         self.assertEqual(
             clients.get_user_agent(),


### PR DESCRIPTION
Now that Kaggle uses the Colab as a base image, the `COLAB_RELEASE_TAG` environment variable is set in the Kaggle image which is not a good signal to detect whether we are running in the Colab environment or not and this has caused the following issue: https://b/399118140.

Updated the Colab environment detection logic to rely on the ipython kernel name instead and save that value to avoid having to recompute it each time `is_in_colab_notebook` is called.

I also fixed `get_colab_credentials` to ensure it doesn't fail when used in the wrong environment and simply skip (same as if the credentials were not found). This wasn't necessary given this is gated by `is_in_colab_notebook()` but it adds extra safety. 

BUG=b/399118140