### PR TITLE
Add a sentence to README.md and ignore a lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ First, you will need a Kaggle account. You can sign up [here](https://www.kaggle
 
 After login, you can download your Kaggle API credentials at https://www.kaggle.com/settings by clicking on the "Create New Token" button under the "API" section.
 
-You have 3 different options to authenticate.
+You have four different options to authenticate. Note that if you use `kaggle-api` (the `kaggle` command-line tool) you have
+already done Option 3 and can skip this.
 
 #### Option 1: Calling kagglehub.login()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,8 +186,6 @@ ignore = [
   "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
   # Ignore tarfile-unsafe-members
   "S202",
-  # Ignore types of default values
-  "PLW1508",
 ]
 unfixable = [
   # Don't touch unused imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,8 @@ ignore = [
   "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
   # Ignore tarfile-unsafe-members
   "S202",
+  # Ignore types of default values
+  "PLW1508",
 ]
 unfixable = [
   # Don't touch unused imports

--- a/src/kagglehub/logger.py
+++ b/src/kagglehub/logger.py
@@ -39,7 +39,7 @@ def _configure_logger(log_dir: Optional[Path] = None) -> None:
         handler = library_logger.handlers.pop()
         while handler.filters:
             handler.filters.pop()
-    logging_enabled = os.environ.get(KAGGLE_LOGGING_ENABLED_ENV_VAR_NAME, False)
+    logging_enabled = os.environ.get(KAGGLE_LOGGING_ENABLED_ENV_VAR_NAME, "False")
     if str(logging_enabled).lower() in ("true", 1):
         log_root_dir = Path(os.environ.get(KAGGLE_LOGGING_ROOT_DIR_ENV_VAR_NAME, Path.home()))
         log_dir = log_root_dir / ".kaggle" / "logs" if log_dir is None else log_dir

--- a/src/kagglehub/logger.py
+++ b/src/kagglehub/logger.py
@@ -39,8 +39,8 @@ def _configure_logger(log_dir: Optional[Path] = None) -> None:
         handler = library_logger.handlers.pop()
         while handler.filters:
             handler.filters.pop()
-    logging_enabled = os.environ.get(KAGGLE_LOGGING_ENABLED_ENV_VAR_NAME, "False")
-    if str(logging_enabled).lower() in ("true", 1):
+    logging_enabled = os.environ.get(KAGGLE_LOGGING_ENABLED_ENV_VAR_NAME, "false")
+    if logging_enabled.lower() in ("true", 1):
         log_root_dir = Path(os.environ.get(KAGGLE_LOGGING_ROOT_DIR_ENV_VAR_NAME, Path.home()))
         log_dir = log_root_dir / ".kaggle" / "logs" if log_dir is None else log_dir
         log_dir.mkdir(exist_ok=True, parents=True)


### PR DESCRIPTION
This fixes the checks that failed in #234.

One of them *did* fail on the first run, but succeeded when I reran it. I think the error was that a socket was in use. Might still have some work to do.