### PR TITLE
Fix `model_signing` breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next Release
 
-*
+* Fix `model_signing` breaking changes from `1.0.0` release
 
 ## v0.3.11 (April 1, 2025)
 

--- a/src/kagglehub/signing.py
+++ b/src/kagglehub/signing.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 def sign_with_sigstore(local_model_dir: str, handle: ModelHandle) -> bool:
-    from model_signing.api import SigningConfig
+    from model_signing.signing import Config
 
     try:
         token = signing_token(handle.owner, handle.model)
@@ -18,7 +18,7 @@ def sign_with_sigstore(local_model_dir: str, handle: ModelHandle) -> bool:
             signing_file.unlink(missing_ok=True)
             # The below will throw an exception if the token can't be verified (Needs to be a production token)
             # Setting KAGGLE_API_ENDPOINT to localhost will throw the exception as stated above.
-            SigningConfig().set_sigstore_signer(identity_token=token, use_staging=False).sign(
+            Config().use_sigstore_signer(identity_token=token, use_staging=False).sign(
                 Path(local_model_dir), signing_file
             )
             return True

--- a/tests/test_model_upload.py
+++ b/tests/test_model_upload.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import mock
 
-from model_signing.api import SigningConfig
+from model_signing.signing import Config
 
 from kagglehub.exceptions import BackendError
 from kagglehub.gcs_upload import MAX_FILES_TO_UPLOAD, TEMP_ARCHIVE_FILE
@@ -132,7 +132,7 @@ class TestModelUpload(BaseTestCase):
                 model_path.mkdir(exist_ok=True, parents=True)
                 metadata_file_path.touch()
 
-            with mock.patch.object(SigningConfig, "sign", side_effect=mock_sign):
+            with mock.patch.object(Config, "sign", side_effect=mock_sign):
                 model_upload("meta/llama3.2/pytorch/70b", str(models_dir), sigstore=True)
                 expected_files = ["my-model.txt", "signing.json"]
                 self.assertCountEqual(set(stub.shared_data.files), expected_files)


### PR DESCRIPTION
[Release history](https://pypi.org/project/model-signing/#history)

Discovered on #238 and fixed on a commit there, but that may be a feature branch for a little longer and this fix should probably get in ASAP.