### PR TITLE
Enable to follow symbolic link directories when dataset upload

### DIFF
--- a/src/kagglehub/datasets.py
+++ b/src/kagglehub/datasets.py
@@ -49,6 +49,7 @@ def dataset_upload(
     local_dataset_dir: str,
     version_notes: str = "",
     ignore_patterns: Optional[Union[list[str], str]] = None,
+    follow_links: bool = False,
 ) -> None:
     """Upload dataset files.
     Args:
@@ -62,6 +63,7 @@ def dataset_upload(
             https://docs.python.org/3/library/fnmatch.html.
             Use a pattern ending with "/" to ignore the whole dir,
             e.g., ".git/" is equivalent to ".git/*".
+        follow_links: (bool) Enable to follow symbolic linked directories.
     """
     h = parse_dataset_handle(handle)
     logger.info(f"Uploading Dataset {h.to_url()} ...")
@@ -73,6 +75,7 @@ def dataset_upload(
         local_dataset_dir,
         item_type="dataset",
         ignore_patterns=normalize_patterns(default=DEFAULT_IGNORE_PATTERNS, additional=ignore_patterns),
+        follow_links=follow_links,
     )
 
     create_dataset_or_version(h, tokens, version_notes)

--- a/src/kagglehub/datasets.py
+++ b/src/kagglehub/datasets.py
@@ -49,6 +49,7 @@ def dataset_upload(
     local_dataset_dir: str,
     version_notes: str = "",
     ignore_patterns: Optional[Union[list[str], str]] = None,
+    *,
     follow_links: bool = False,
 ) -> None:
     """Upload dataset files.
@@ -63,7 +64,7 @@ def dataset_upload(
             https://docs.python.org/3/library/fnmatch.html.
             Use a pattern ending with "/" to ignore the whole dir,
             e.g., ".git/" is equivalent to ".git/*".
-        follow_links: (bool) Enable to follow symbolic linked directories.
+        follow_links: (bool) Enable to follow symbolic link directories.
     """
     h = parse_dataset_handle(handle)
     logger.info(f"Uploading Dataset {h.to_url()} ...")

--- a/src/kagglehub/gcs_upload.py
+++ b/src/kagglehub/gcs_upload.py
@@ -218,16 +218,17 @@ def _check_uploadable_files(folder: str, *, ignore_patterns: Sequence[str], foll
                 symlinked_dirs.add(dir_p)
         file_count += len(files)
 
-    if file_count == 0 and os.path.isdir(folder):
-        no_uploadable_exception = "No uploadable files are found. At least one file is needed."
-        raise ValueError(no_uploadable_exception)
-
     n_links = len(symlinked_dirs)
     if not follow_links and n_links > 0:
         logger.warning(
             f"Skip {n_links} symbolic link directories."
             " If you want to include these directores, set `follow_links=True`."
         )
+
+    if file_count == 0 and os.path.isdir(folder):
+        no_uploadable_exception = "No uploadable files are found. At least one file is needed."
+        raise ValueError(no_uploadable_exception)
+
     return file_count
 
 

--- a/tests/test_gcs_upload.py
+++ b/tests/test_gcs_upload.py
@@ -62,9 +62,8 @@ class TesModelsHelpers(BaseTestCase):
                     walked_files.append(pathlib.Path(dir_path) / file_name)
             self.assertEqual(set(walked_files), expected_files)
 
-
-    def _setup_link_dir(self, tmp_dir_p: pathlib.Path):
-        """ setup the following structure
+    def _setup_link_dir(self, tmp_dir_p: pathlib.Path) -> None:
+        """setup the following structure
         tmp_dir/
           root/
             link_dir -> tmp_dir/extern/
@@ -76,7 +75,7 @@ class TesModelsHelpers(BaseTestCase):
         """
         extern_dir = tmp_dir_p / "extern"
         extern_dir.mkdir()
-        (extern_dir / "b.txt") .touch()
+        (extern_dir / "b.txt").touch()
         (extern_dir / "loop_dir").symlink_to(extern_dir, target_is_directory=True)
 
         root_dir = tmp_dir_p / "root"
@@ -100,7 +99,9 @@ class TesModelsHelpers(BaseTestCase):
                 root_dir / "link_dir" / "b.txt",
             }
             walked_files = []
-            for dir_path, _, file_names in filtered_walk(base_dir=root_dir, ignore_patterns=[], follow_links=follow_links):
+            for dir_path, _, file_names in filtered_walk(
+                base_dir=root_dir, ignore_patterns=[], follow_links=follow_links
+            ):
                 for file_name in file_names:
                     walked_files.append(pathlib.Path(dir_path) / file_name)
             self.assertEqual(set(walked_files), expected_files)
@@ -120,7 +121,9 @@ class TesModelsHelpers(BaseTestCase):
                 root_dir / "real_dir" / "a.txt",
             }
             walked_files = []
-            for dir_path, _, file_names in filtered_walk(base_dir=root_dir, ignore_patterns=[], follow_links=follow_links):
+            for dir_path, _, file_names in filtered_walk(
+                base_dir=root_dir, ignore_patterns=[], follow_links=follow_links
+            ):
                 for file_name in file_names:
                     walked_files.append(pathlib.Path(dir_path) / file_name)
             self.assertEqual(set(walked_files), expected_files)

--- a/tests/test_gcs_upload.py
+++ b/tests/test_gcs_upload.py
@@ -61,3 +61,66 @@ class TesModelsHelpers(BaseTestCase):
                 for file_name in file_names:
                     walked_files.append(pathlib.Path(dir_path) / file_name)
             self.assertEqual(set(walked_files), expected_files)
+
+
+    def _setup_link_dir(self, tmp_dir_p: pathlib.Path):
+        """ setup the following structure
+        tmp_dir/
+          root/
+            link_dir -> tmp_dir/extern/
+            real_dir/
+              a.txt
+          extern/
+              loop_dir -> tmp_dir/extern/
+              b.txt
+        """
+        extern_dir = tmp_dir_p / "extern"
+        extern_dir.mkdir()
+        (extern_dir / "b.txt") .touch()
+        (extern_dir / "loop_dir").symlink_to(extern_dir, target_is_directory=True)
+
+        root_dir = tmp_dir_p / "root"
+        (root_dir / "real_dir").mkdir(parents=True)
+        (root_dir / "real_dir" / "a.txt").touch()
+        (root_dir / "link_dir").symlink_to(extern_dir, target_is_directory=True)
+
+    def test_follow_link_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir_p = pathlib.Path(tmp_dir)
+
+            try:
+                self._setup_link_dir(tmp_dir_p)
+            except Exception:
+                self.skipTest("failed to setup linked dir")
+
+            follow_links = True
+            root_dir = tmp_dir_p / "root"
+            expected_files = {
+                root_dir / "real_dir" / "a.txt",
+                root_dir / "link_dir" / "b.txt",
+            }
+            walked_files = []
+            for dir_path, _, file_names in filtered_walk(base_dir=root_dir, ignore_patterns=[], follow_links=follow_links):
+                for file_name in file_names:
+                    walked_files.append(pathlib.Path(dir_path) / file_name)
+            self.assertEqual(set(walked_files), expected_files)
+
+    def test_skip_link_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir_p = pathlib.Path(tmp_dir)
+
+            try:
+                self._setup_link_dir(tmp_dir_p)
+            except Exception:
+                self.skipTest("failed to setup linked dir")
+
+            follow_links = False
+            root_dir = tmp_dir_p / "root"
+            expected_files = {
+                root_dir / "real_dir" / "a.txt",
+            }
+            walked_files = []
+            for dir_path, _, file_names in filtered_walk(base_dir=root_dir, ignore_patterns=[], follow_links=follow_links):
+                for file_name in file_names:
+                    walked_files.append(pathlib.Path(dir_path) / file_name)
+            self.assertEqual(set(walked_files), expected_files)


### PR DESCRIPTION
In this PR, I want to allow following symbolic link directories when uploading a dataset.

The current implementation looks to silently ignore symbolic link directories when upload a dataset because of `os.walk`'s default behavior.
This can confuse the user. In particular, it is possible that missing only a portion of the dataset will cause a slight mismatch in the model's performance between trained by the original and uploaded datasets. Identifying the cause of such problems can be difficult.

So I want to add a flag that allows following symbolic link directories and add some log messages that inform for user when some directories are skipped.

related issue? #119 

I would appreciate it if you could review this.