### PR TITLE
Add more arguments on resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Next Release
 
-* 
+* Add `max_workers` on `model_download`
+* Use `tqdm.auto` instead of `tqdm`
 
 ## v0.3.12 (April 23, 2025)
 

--- a/src/kagglehub/clients.py
+++ b/src/kagglehub/clients.py
@@ -13,7 +13,7 @@ import requests
 import requests.auth
 from packaging.version import parse
 from requests.auth import HTTPBasicAuth
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 import kagglehub
 from kagglehub.cache import delete_from_cache, get_cached_archive_path

--- a/src/kagglehub/gcs_upload.py
+++ b/src/kagglehub/gcs_upload.py
@@ -11,7 +11,7 @@ from typing import Optional, Union
 
 import requests
 from requests.exceptions import Timeout
-from tqdm import tqdm
+from tqdm.auto import tqdm
 from tqdm.utils import CallbackIOWrapper
 
 from kagglehub.clients import KaggleApiV1Client

--- a/src/kagglehub/http_resolver.py
+++ b/src/kagglehub/http_resolver.py
@@ -189,7 +189,8 @@ class ModelHttpResolver(Resolver[ModelHandle]):
                     os.makedirs(os.path.dirname(file_out_path), exist_ok=True)
                     api_client.download_file(url_path + "/" + file, file_out_path, h)
 
-                if kwargs["max_workers"] > 8:
+                max_workers = 8 if "max_workers" not in kwargs else kwargs["max_workers"]
+                if max_workers > 8:
                     logger.warning(
                         "Downloading files in parallel with more than 8 threads is not recommended. "
                         "This may lead to throttling or connection issues."
@@ -199,7 +200,7 @@ class ModelHttpResolver(Resolver[ModelHandle]):
                     _inner_download_file,
                     files,
                     desc=f"Downloading {len(files)} files",
-                    max_workers=min(8, kwargs["max_workers"]),  # Never use more than 8 threads in parallel to download files.
+                    max_workers=min(8, max_workers),  # Never use more than 8 threads in parallel to download files.
                 )
 
         mark_as_complete(h, path)

--- a/src/kagglehub/resolver.py
+++ b/src/kagglehub/resolver.py
@@ -13,7 +13,7 @@ class Resolver(Generic[T]):
     __metaclass__ = abc.ABCMeta
 
     def __call__(
-        self, handle: T, path: Optional[str] = None, *, force_download: Optional[bool] = False
+        self, handle: T, path: Optional[str] = None, *, force_download: Optional[bool] = False, **kwargs
     ) -> tuple[str, Optional[int]]:
         """Resolves a handle into a path with the requested file(s) and the resource's version number.
 
@@ -26,7 +26,7 @@ class Resolver(Generic[T]):
             A tuple of: (string representing the path, version number of resolved datasource if present)
             Some cases where version number might be missing: Competition datasource, API-based models.
         """
-        path, version = self._resolve(handle, path, force_download=force_download)
+        path, version = self._resolve(handle, path, force_download=force_download, **kwargs)
 
         # Note handles are immutable, so _resolve() could not have altered our reference
         register_datasource_access(handle, version)
@@ -35,7 +35,7 @@ class Resolver(Generic[T]):
 
     @abc.abstractmethod
     def _resolve(
-        self, handle: T, path: Optional[str] = None, *, force_download: Optional[bool] = False
+        self, handle: T, path: Optional[str] = None, *, force_download: Optional[bool] = False, **kwargs
     ) -> tuple[str, Optional[int]]:
         """Resolves a handle into a path with the requested file(s) and the resource's version number.
 


### PR DESCRIPTION
1. Add `max_workers` argument on `model_download`. 

I find in some internet environment, multiprocessing download will be much slower because of network congestion, so set `max_workers` by user is needed. Default it will be 8 and will check if > 8 and throw warning.

Also add `**kwargs` will be flexible for future development(Like adding more arguments) considering the code structure, so I choose to use it instead of hardcore `max_workers`.

2. Use `tqdm.auto` instead of `tqdm`.

In my local jupyter environment, I find tqdm print too much even causing browser OOM, also output will not be pretty. Use `tqdm.auto`  is a more suitable way.