### PR TITLE
Add support for custom target download directory in dataset resolvers

### DIFF
--- a/src/kagglehub/colab_cache_resolver.py
+++ b/src/kagglehub/colab_cache_resolver.py
@@ -118,11 +118,16 @@ class DatasetColabCacheResolver(Resolver[DatasetHandle]):
         return True
 
     def _resolve(
-        self, h: DatasetHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False
+        self, h: DatasetHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False, target_path: Optional[str] = None
     ) -> tuple[str, Optional[int]]:
         if force_download:
             logger.info(
                 "Ignoring `force_download` argument when running inside the Colab notebook environment.",
+                extra={**EXTRA_CONSOLE_BLOCK},
+            )
+        if target_path:
+            logger.info(
+                "Ignoring `target_path` argument when running inside the Colab notebook environment.",
                 extra={**EXTRA_CONSOLE_BLOCK},
             )
 

--- a/src/kagglehub/colab_cache_resolver.py
+++ b/src/kagglehub/colab_cache_resolver.py
@@ -42,11 +42,21 @@ class ModelColabCacheResolver(Resolver[ModelHandle]):
         return True
 
     def _resolve(
-        self, h: ModelHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False
+        self,
+        h: ModelHandle,
+        path: Optional[str] = None,
+        *,
+        force_download: Optional[bool] = False,
+        target_path: Optional[str] = None,
     ) -> tuple[str, Optional[int]]:
         if force_download:
             logger.info(
                 "Ignoring `force_download` argument when running inside the Colab notebook environment.",
+                extra={**EXTRA_CONSOLE_BLOCK},
+            )
+        if target_path:
+            logger.info(
+                "Ignoring `target_path` argument when running inside the Colab notebook environment.",
                 extra={**EXTRA_CONSOLE_BLOCK},
             )
 
@@ -118,7 +128,12 @@ class DatasetColabCacheResolver(Resolver[DatasetHandle]):
         return True
 
     def _resolve(
-        self, h: DatasetHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False, target_path: Optional[str] = None
+        self,
+        h: DatasetHandle,
+        path: Optional[str] = None,
+        *,
+        force_download: Optional[bool] = False,
+        target_path: Optional[str] = None,
     ) -> tuple[str, Optional[int]]:
         if force_download:
             logger.info(

--- a/src/kagglehub/datasets.py
+++ b/src/kagglehub/datasets.py
@@ -29,18 +29,19 @@ _DATASET_LOAD_VALID_KWARGS_MAP = {
 }
 
 
-def dataset_download(handle: str, path: Optional[str] = None, *, force_download: Optional[bool] = False) -> str:
+def dataset_download(handle: str, path: Optional[str] = None, *, target_path: Optional[str] = None, force_download: Optional[bool] = False) -> str:
     """Download dataset files
     Args:
         handle: (string) the dataset handle
         path: (string) Optional path to a file within a dataset
+        target_path: (string) Optional path to a directory where the dataset files will be downloaded.
         force_download: (bool) Optional flag to force download a dataset, even if it's cached
     Returns:
         A string requesting the path to the requested dataset files.
     """
     h = parse_dataset_handle(handle)
     logger.info(f"Downloading Dataset: {h.to_url()} ...", extra={**EXTRA_CONSOLE_BLOCK})
-    path, _ = registry.dataset_resolver(h, path, force_download=force_download)
+    path, _ = registry.dataset_resolver(h, path, force_download=force_download, target_path=target_path)
     return path
 
 

--- a/src/kagglehub/http_resolver.py
+++ b/src/kagglehub/http_resolver.py
@@ -18,6 +18,7 @@ from kagglehub.cache import (
 from kagglehub.clients import KaggleApiV1Client
 from kagglehub.exceptions import UnauthenticatedError
 from kagglehub.handle import CompetitionHandle, DatasetHandle, ModelHandle, NotebookHandle, ResourceHandle
+from kagglehub.logger import EXTRA_CONSOLE_BLOCK
 from kagglehub.packages import PackageScope
 from kagglehub.resolver import Resolver
 
@@ -36,8 +37,18 @@ class CompetitionHttpResolver(Resolver[CompetitionHandle]):
         return True
 
     def _resolve(
-        self, h: CompetitionHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False
+        self,
+        h: CompetitionHandle,
+        path: Optional[str] = None,
+        *,
+        force_download: Optional[bool] = False,
+        target_path: Optional[str] = None,
     ) -> tuple[str, Optional[int]]:
+        if target_path:
+            logger.info(
+                "Ignoring `target_path` argument for competition downloads.",
+                extra={**EXTRA_CONSOLE_BLOCK},
+            )
         api_client = KaggleApiV1Client()
 
         cached_path = load_from_cache(h, path)
@@ -100,7 +111,12 @@ class DatasetHttpResolver(Resolver[DatasetHandle]):
         return True
 
     def _resolve(
-        self, h: DatasetHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False, target_path: Optional[str] = None
+        self,
+        h: DatasetHandle,
+        path: Optional[str] = None,
+        *,
+        force_download: Optional[bool] = False,
+        target_path: Optional[str] = None,
     ) -> tuple[str, Optional[int]]:
         api_client = KaggleApiV1Client()
 
@@ -154,8 +170,18 @@ class ModelHttpResolver(Resolver[ModelHandle]):
         return True
 
     def _resolve(
-        self, h: ModelHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False
+        self,
+        h: ModelHandle,
+        path: Optional[str] = None,
+        *,
+        force_download: Optional[bool] = False,
+        target_path: Optional[str] = None,
     ) -> tuple[str, Optional[int]]:
+        if target_path:
+            logger.info(
+                "Ignoring `target_path` argument for model downloads.",
+                extra={**EXTRA_CONSOLE_BLOCK},
+            )
         api_client = KaggleApiV1Client()
 
         if not h.is_versioned():
@@ -216,8 +242,18 @@ class NotebookOutputHttpResolver(Resolver[NotebookHandle]):
         return True
 
     def _resolve(
-        self, h: NotebookHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False
+        self,
+        h: NotebookHandle,
+        path: Optional[str] = None,
+        *,
+        force_download: Optional[bool] = False,
+        target_path: Optional[str] = None,
     ) -> tuple[str, Optional[int]]:
+        if target_path:
+            logger.info(
+                "Ignoring `target_path` argument for notebook output downloads.",
+                extra={**EXTRA_CONSOLE_BLOCK},
+            )
         api_client = KaggleApiV1Client()
 
         if not h.is_versioned():

--- a/src/kagglehub/kaggle_cache_resolver.py
+++ b/src/kagglehub/kaggle_cache_resolver.py
@@ -38,12 +38,22 @@ class CompetitionKaggleCacheResolver(Resolver[CompetitionHandle]):
         return False
 
     def _resolve(
-        self, h: CompetitionHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False
+        self,
+        h: CompetitionHandle,
+        path: Optional[str] = None,
+        *,
+        force_download: Optional[bool] = False,
+        target_path: Optional[str] = None,
     ) -> tuple[str, Optional[int]]:
         client = KaggleJwtClient()
         if force_download:
             logger.info(
                 "Ignoring `force_download` argument when running inside the Kaggle notebook environment.",
+                extra={**EXTRA_CONSOLE_BLOCK},
+            )
+        if target_path:
+            logger.info(
+                "Ignoring `target_path` argument when running inside the Kaggle notebook environment.",
                 extra={**EXTRA_CONSOLE_BLOCK},
             )
 
@@ -102,7 +112,12 @@ class DatasetKaggleCacheResolver(Resolver[DatasetHandle]):
         return False
 
     def _resolve(
-        self, h: DatasetHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False, target_path: Optional[str] = None
+        self,
+        h: DatasetHandle,
+        path: Optional[str] = None,
+        *,
+        force_download: Optional[bool] = False,
+        target_path: Optional[str] = None,
     ) -> tuple[str, Optional[int]]:
         if force_download:
             logger.info(
@@ -182,11 +197,21 @@ class ModelKaggleCacheResolver(Resolver[ModelHandle]):
         return False
 
     def _resolve(
-        self, h: ModelHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False
+        self,
+        h: ModelHandle,
+        path: Optional[str] = None,
+        *,
+        force_download: Optional[bool] = False,
+        target_path: Optional[str] = None,
     ) -> tuple[str, Optional[int]]:
         if force_download:
             logger.info(
                 "Ignoring `force_download` argument when running inside the Kaggle notebook environment.",
+                extra={**EXTRA_CONSOLE_BLOCK},
+            )
+        if target_path:
+            logger.info(
+                "Ignoring `target_path` argument when running inside the Kaggle notebook environment.",
                 extra={**EXTRA_CONSOLE_BLOCK},
             )
         client = KaggleJwtClient()
@@ -259,11 +284,21 @@ class NotebookOutputKaggleCacheResolver(Resolver[NotebookHandle]):
         return False
 
     def _resolve(
-        self, h: NotebookHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False
+        self,
+        h: NotebookHandle,
+        path: Optional[str] = None,
+        *,
+        force_download: Optional[bool] = False,
+        target_path: Optional[str] = None,
     ) -> tuple[str, Optional[int]]:
         if force_download:
             logger.info(
                 "Ignoring `force_download` argument when running inside the Kaggle notebook environment.",
+                extra={**EXTRA_CONSOLE_BLOCK},
+            )
+        if target_path:
+            logger.info(
+                "Ignoring `target_path` argument when running inside the Kaggle notebook environment.",
                 extra={**EXTRA_CONSOLE_BLOCK},
             )
         client = KaggleJwtClient()

--- a/src/kagglehub/kaggle_cache_resolver.py
+++ b/src/kagglehub/kaggle_cache_resolver.py
@@ -102,11 +102,16 @@ class DatasetKaggleCacheResolver(Resolver[DatasetHandle]):
         return False
 
     def _resolve(
-        self, h: DatasetHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False
+        self, h: DatasetHandle, path: Optional[str] = None, *, force_download: Optional[bool] = False, target_path: Optional[str] = None
     ) -> tuple[str, Optional[int]]:
         if force_download:
             logger.info(
                 "Ignoring `force_download` argument when running inside the Kaggle notebook environment.",
+                extra={**EXTRA_CONSOLE_BLOCK},
+            )
+        if target_path:
+            logger.info(
+                "Ignoring `target_path` argument when running inside the Kaggle notebook environment.",
                 extra={**EXTRA_CONSOLE_BLOCK},
             )
         client = KaggleJwtClient()

--- a/src/kagglehub/resolver.py
+++ b/src/kagglehub/resolver.py
@@ -13,7 +13,7 @@ class Resolver(Generic[T]):
     __metaclass__ = abc.ABCMeta
 
     def __call__(
-        self, handle: T, path: Optional[str] = None, *, force_download: Optional[bool] = False
+        self, handle: T, path: Optional[str] = None, *, force_download: Optional[bool] = False, target_path: Optional[str] = None
     ) -> tuple[str, Optional[int]]:
         """Resolves a handle into a path with the requested file(s) and the resource's version number.
 
@@ -21,12 +21,13 @@ class Resolver(Generic[T]):
             handle: (T) the ResourceHandle to resolve.
             path: (string) Optional path to a file within the resource.
             force_download: (bool) Optional flag to force download, even if it's cached.
+            target_path: (string) Optional path to a directory where the files will be downloaded.
 
         Returns:
             A tuple of: (string representing the path, version number of resolved datasource if present)
             Some cases where version number might be missing: Competition datasource, API-based models.
         """
-        path, version = self._resolve(handle, path, force_download=force_download)
+        path, version = self._resolve(handle, path, force_download=force_download, target_path=target_path)
 
         # Note handles are immutable, so _resolve() could not have altered our reference
         register_datasource_access(handle, version)
@@ -35,7 +36,7 @@ class Resolver(Generic[T]):
 
     @abc.abstractmethod
     def _resolve(
-        self, handle: T, path: Optional[str] = None, *, force_download: Optional[bool] = False
+        self, handle: T, path: Optional[str] = None, *, force_download: Optional[bool] = False, target_path: Optional[str] = None
     ) -> tuple[str, Optional[int]]:
         """Resolves a handle into a path with the requested file(s) and the resource's version number.
 
@@ -43,6 +44,7 @@ class Resolver(Generic[T]):
             handle: (T) the ResourceHandle to resolve.
             path: (string) Optional path to a file within the resource.
             force_download: (bool) Optional flag to force download, even if it's cached.
+            target_path: (string) Optional path to a directory where the files will be downloaded.
 
         Returns:
             A tuple of: (string representing the path, version number of resolved datasource if present)

--- a/tests/test_colab_cache_dataset_download.py
+++ b/tests/test_colab_cache_dataset_download.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from unittest import mock
 
 import requests
@@ -72,6 +73,21 @@ class TestColabCacheDatasetDownload(BaseTestCase):
     def test_versioned_dataset_download_bad_handle_raises(self) -> None:
         with self.assertRaises(ValueError):
             kagglehub.dataset_download("bad handle")
+
+    def test_versioned_dataset_download_with_target_path(self) -> None:
+        with stub.create_env():
+            target_dir = os.path.join(os.getcwd(), "custom_target")
+            os.makedirs(target_dir, exist_ok=True)
+            try:
+                dataset_path = kagglehub.dataset_download(VERSIONED_DATASET_HANDLE, target_path=target_dir)
+                # Colab cache resolver ignores target_path, so it should return the original path
+                self.assertNotEqual(target_dir, os.path.dirname(dataset_path))
+                # Check that original dataset path has expected ending
+                self.assertTrue(dataset_path.endswith("/1"))
+            finally:
+                # Clean up
+                if os.path.exists(target_dir):
+                    shutil.rmtree(target_dir)
 
 
 class TestNoInternetColabCacheModelDownload(BaseTestCase):

--- a/tests/test_http_dataset_download.py
+++ b/tests/test_http_dataset_download.py
@@ -48,26 +48,46 @@ class TestHttpDatasetDownload(BaseTestCase):
         dataset_handle: str,
         expected_subdir_or_subpath: str,
         expected_files: Optional[list[str]] = None,
+        expected_target_path: Optional[str] = None,
         **kwargs,  # noqa: ANN003
     ) -> None:
         # Download the full datasets and ensure all files are there.
         dataset_path = kagglehub.dataset_download(dataset_handle, **kwargs)
 
-        self.assertEqual(os.path.join(d, expected_subdir_or_subpath), dataset_path)
+        # If target_path was specified, check that the file was copied there
+        if expected_target_path:
+            self.assertEqual(expected_target_path, dataset_path)
+            self.assertTrue(os.path.exists(expected_target_path))
+        else:
+            self.assertEqual(os.path.join(d, expected_subdir_or_subpath), dataset_path)
+
+        path_to_check = dataset_path
 
         if not expected_files:
             expected_files = ["foo.txt"]
-        self.assertEqual(sorted(expected_files), sorted(os.listdir(dataset_path)))
+        self.assertEqual(sorted(expected_files), sorted(os.listdir(path_to_check)))
 
         # Assert that the archive file has been deleted
         archive_path = get_cached_archive_path(parse_dataset_handle(dataset_handle))
         self.assertFalse(os.path.exists(archive_path))
 
-    def _download_test_file_and_assert_downloaded(self, d: str, dataset_handle: str, **kwargs) -> None:  # noqa: ANN003
+    def _download_test_file_and_assert_downloaded(
+        self,
+        d: str,
+        dataset_handle: str,
+        expected_target_path: Optional[str] = None,
+        **kwargs,  # noqa: ANN003
+    ) -> None:
         dataset_path = kagglehub.dataset_download(dataset_handle, path=TEST_FILEPATH, **kwargs)
-        self.assertEqual(os.path.join(d, EXPECTED_DATASET_SUBPATH, TEST_FILEPATH), dataset_path)
-        with open(dataset_path) as dataset_file:
-            self.assertEqual(TEST_CONTENTS, dataset_file.read())
+        
+        if expected_target_path:
+            self.assertEqual(expected_target_path, dataset_path)
+            with open(dataset_path) as dataset_file:
+                self.assertEqual(TEST_CONTENTS, dataset_file.read())
+        else:
+            self.assertEqual(os.path.join(d, EXPECTED_DATASET_SUBPATH, TEST_FILEPATH), dataset_path)
+            with open(dataset_path) as dataset_file:
+                self.assertEqual(TEST_CONTENTS, dataset_file.read())
 
     def _download_test_file_and_assert_downloaded_auto_compressed(
         self,
@@ -133,3 +153,26 @@ class TestHttpDatasetDownload(BaseTestCase):
             # Download a single file first
             kagglehub.dataset_download(UNVERSIONED_DATASET_HANDLE, path=TEST_FILEPATH)
             self._download_dataset_and_assert_downloaded(d, UNVERSIONED_DATASET_HANDLE, EXPECTED_DATASET_SUBDIR)
+
+    def test_versioned_dataset_download_with_target_path(self) -> None:
+        with create_test_cache() as d:
+            target_dir = os.path.join(d, "custom_target")
+            os.makedirs(target_dir, exist_ok=True)
+            self._download_dataset_and_assert_downloaded(
+                d,
+                VERSIONED_DATASET_HANDLE,
+                EXPECTED_DATASET_SUBDIR,
+                target_path=target_dir,
+                expected_target_path=os.path.join(target_dir, os.path.basename(EXPECTED_DATASET_SUBPATH))
+            )
+
+    def test_versioned_dataset_download_with_path_and_target_path(self) -> None:
+        with create_test_cache() as d:
+            target_dir = os.path.join(d, "custom_target")
+            os.makedirs(target_dir, exist_ok=True)
+            self._download_test_file_and_assert_downloaded(
+                d,
+                VERSIONED_DATASET_HANDLE,
+                target_path=target_dir,
+                expected_target_path=os.path.join(target_dir, TEST_FILEPATH)
+            )

--- a/tests/test_http_dataset_download.py
+++ b/tests/test_http_dataset_download.py
@@ -79,7 +79,7 @@ class TestHttpDatasetDownload(BaseTestCase):
         **kwargs,  # noqa: ANN003
     ) -> None:
         dataset_path = kagglehub.dataset_download(dataset_handle, path=TEST_FILEPATH, **kwargs)
-        
+
         if expected_target_path:
             self.assertEqual(expected_target_path, dataset_path)
             with open(dataset_path) as dataset_file:
@@ -163,7 +163,7 @@ class TestHttpDatasetDownload(BaseTestCase):
                 VERSIONED_DATASET_HANDLE,
                 EXPECTED_DATASET_SUBDIR,
                 target_path=target_dir,
-                expected_target_path=os.path.join(target_dir, os.path.basename(EXPECTED_DATASET_SUBPATH))
+                expected_target_path=os.path.join(target_dir, os.path.basename(EXPECTED_DATASET_SUBPATH)),
             )
 
     def test_versioned_dataset_download_with_path_and_target_path(self) -> None:
@@ -174,5 +174,5 @@ class TestHttpDatasetDownload(BaseTestCase):
                 d,
                 VERSIONED_DATASET_HANDLE,
                 target_path=target_dir,
-                expected_target_path=os.path.join(target_dir, TEST_FILEPATH)
+                expected_target_path=os.path.join(target_dir, TEST_FILEPATH),
             )

--- a/tests/test_kaggle_cache_dataset_download.py
+++ b/tests/test_kaggle_cache_dataset_download.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from unittest import mock
 
 import requests
@@ -84,3 +85,18 @@ class TestKaggleCacheDatasetDownload(BaseTestCase):
         with stub.create_env():
             dataset_path = kagglehub.dataset_download(VERSIONED_DATASET_HANDLE, force_download=False)
             self.assertEqual(["foo.txt"], sorted(os.listdir(dataset_path)))
+
+    def test_versioned_dataset_download_with_target_path(self) -> None:
+        with stub.create_env():
+            target_dir = os.path.join(os.getcwd(), "custom_target")
+            os.makedirs(target_dir, exist_ok=True)
+            try:
+                dataset_path = kagglehub.dataset_download(VERSIONED_DATASET_HANDLE, target_path=target_dir)
+                # Kaggle cache resolver ignores target_path, so it should return the original path
+                self.assertNotEqual(target_dir, os.path.dirname(dataset_path))
+                # Check that original dataset path contains expected files
+                self.assertEqual(["foo.txt"], sorted(os.listdir(dataset_path)))
+            finally:
+                # Clean up
+                if os.path.exists(target_dir):
+                    shutil.rmtree(target_dir)


### PR DESCRIPTION
Enhance dataset download functionality by introducing a `target_path` parameter, allowing users to specify a custom directory for downloaded datasets. Include tests to verify the correct behavior of this new feature. Closes #214 #175 #179