### PR TITLE
Revert previous mypy exception after retiring Python3.9.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,7 +237,3 @@ exclude_lines = [
 
 [tool.mypy]
 mypy_path = "./stubs"
-
-[[tool.mypy.overrides]]
-module = ["yaml.*"]
-ignore_missing_imports = true


### PR DESCRIPTION
Revert the added mypy exceptions from [PR](https://github.com/Kaggle/kagglehub/pull/256/) since we have retried Python 3.9 so the cicd should just work.