### PR TITLE
Persist kagglehub cache between docker-hatch calls.

### DIFF
--- a/docker-hatch
+++ b/docker-hatch
@@ -69,4 +69,4 @@ docker build -f Dockerfile \
     .
 
 set -x
-docker run --rm -v $PWD:/working -v ~/.kaggle:/root/.kaggle -w /working ${DOCKER_IMAGE} "$@"
+docker run --rm -v $PWD:/working -v ~/.kaggle:/root/.kaggle -v ~/.cache/kagglehub:/root/.cache/kagglehub -w /working ${DOCKER_IMAGE} "$@"


### PR DESCRIPTION
This allows accessing the file after the docker-hatch command completes.

It also allows testing the download resuming function & local caching function.

Before this, when `docker-hatch` completed, the local cache inside the Docker container was lost.

http://b/307576378