### PR TITLE
Relax version constraint on kagglesdk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "tqdm",
   "packaging",
   "pyyaml",
-  "kagglesdk==0.1.13",
+  "kagglesdk>=0.1.13, < 1.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
This will prevent issues when installing kagglehub & kaggle-api which may have slightly version requirements. 

As long as kagglesdk respects semver conventions, it will work great.


http://b/468020272