### PR TITLE
docs(readme): fix 'notebok_output_download' -> 'notebook_output_download' typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ kagglehub.notebook_output_download('alexisbcook/titanic-tutorial')
 kagglehub.notebook_output_download('alexisbcook/titanic-tutorial/versions/1')
 
 # Download a single file.
-kagglehub.notebok_output_download('alexisbcook/titanic-tutorial', path='submission.csv')
+kagglehub.notebook_output_download('alexisbcook/titanic-tutorial', path='submission.csv')
 
 # Download notebook output to a custom output directory.
 kagglehub.notebook_output_download('alexisbcook/titanic-tutorial', output_dir='./output')


### PR DESCRIPTION
## Summary

`README.md` has a typo in the *Download Notebook Outputs* section (line 421):

Before:
\`\`\`
kagglehub.notebok_output_download('alexisbcook/titanic-tutorial', path='submission.csv')
\`\`\`

After:
\`\`\`
kagglehub.notebook_output_download('alexisbcook/titanic-tutorial', path='submission.csv')
\`\`\`

Every other occurrence in the same code block already uses the correct `notebook_output_download` function name.

Closes #291

## Testing

Documentation-only change. No code paths affected.