### PR TITLE
Update API token page URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG PYTHON_VERSION
 
 FROM python:${PYTHON_VERSION}
 
-RUN pip install hatch==1.14.0
+RUN pip install hatch==1.16.5
 
 # Add only the minimal files required to be able to pre-create the hatch environments.
 # If any of these files changes, a new Docker build is necessary. This is why we need

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Authenticating is **only** needed to access public resources requiring user cons
 
 First, you will need a Kaggle account. You can sign up [here](https://www.kaggle.com/account/login).
 
-After login, you can download your Kaggle API token at https://www.kaggle.com/settings by clicking on the "Generate New Token" button under the "API" section.
+After login, you can download your Kaggle API token at https://www.kaggle.com/settings/api by clicking on the "Generate New Token" button under the "API" section.
 
 You have several options to authenticate. Note that if you use `kaggle-api` (the `kaggle` command-line tool) you have
 already configured authentication and can skip this.
@@ -55,17 +55,17 @@ export KAGGLE_API_TOKEN=xxxxxxxxxxxxxx # Copied from the settings UI
 
 #### Option 3: API token file
 
-Store your Kaggle API token obtained from your [Kaggle account settings page](https://www.kaggle.com/settings) in a file at `~/.kaggle/access_token`.
+Store your Kaggle API token obtained from your [Kaggle account API tokens settings page](https://www.kaggle.com/settings/api) in a file at `~/.kaggle/access_token`.
 
 #### Option 4: Google Colab secret
 
-Store your Kaggle API token obtained from your [Kaggle account settings page](https://www.kaggle.com/settings) in a Colab secret named `KAGGLE_API_TOKEN`.
+Store your Kaggle API token obtained from your [Kaggle account API tokens settings page](https://www.kaggle.com/settings/api) in a Colab secret named `KAGGLE_API_TOKEN`.
 
 Instructions on adding secrets in both Colab and Colab Enterprise can be found in [this article](https://www.googlecloudcommunity.com/gc/Cloud-Hub/How-do-I-add-secrets-in-Google-Colab-Enterprise/m-p/784866).
 
 #### Option 5: Legacy API credentials file
 
-From your [Kaggle account settings page](https://www.kaggle.com/settings), under "Legacy API Credentials", click on the "Create Legacy API Key" button to generate a `kaggle.json` file and store it at `~/.kaggle/kaggle.json`.
+From your [Kaggle account API tokens settings page](https://www.kaggle.com/settings/api), under "Legacy API Credentials", click on the "Create Legacy API Key" button to generate a `kaggle.json` file and store it at `~/.kaggle/kaggle.json`.
 
 ### Download Model
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Authenticating is **only** needed to access public resources requiring user cons
 
 First, you will need a Kaggle account. You can sign up [here](https://www.kaggle.com/account/login).
 
-After login, you can download your Kaggle API token at https://www.kaggle.com/settings/api by clicking on the "Generate New Token" button under the "API" section.
+After login, you can download your Kaggle API token at https://www.kaggle.com/settings/api by clicking on the "Generate New Token" button.
 
 You have several options to authenticate. Note that if you use `kaggle-api` (the `kaggle` command-line tool) you have
 already configured authentication and can skip this.

--- a/integration_tests/test_package_import.py
+++ b/integration_tests/test_package_import.py
@@ -90,5 +90,5 @@ class TestPackageImport(unittest.TestCase):
             # Uninstall pyjokes now
             del sys.modules["pyjokes"]
             importlib.invalidate_caches()
-            subprocess.check_call([sys.executable, "-m", "pip", "uninstall", "pyjokes", "-y"])  # noqa: S603
+            subprocess.check_call([sys.executable, "-m", "pip", "uninstall", "pyjokes", "-y"])
             self.assertIsNone(importlib.util.find_spec("pyjokes"))

--- a/src/kagglehub/auth.py
+++ b/src/kagglehub/auth.py
@@ -22,8 +22,8 @@ INVALID_CREDENTIALS_ERROR = 401
 NOTEBOOK_LOGIN_TOKEN_HTML_START = """<center> <img
 src=https://www.kaggle.com/static/images/site-logo.png
 alt='Kaggle'> <br> Create an API token from <a
-href="https://www.kaggle.com/settings/account" target="_blank">your Kaggle
-settings page</a> and paste it below. <br> </center>"""
+href="https://www.kaggle.com/settings/api" target="_blank">your Kaggle
+API Tokens settings page</a> and paste it below. <br> </center>"""
 
 NOTEBOOK_LOGIN_TOKEN_HTML_END = """
 <b>Thank You</b></center>"""
@@ -131,7 +131,7 @@ def _validate_credentials_helper(*, verbose: bool = True) -> str | None:
         elif "code" in response and response["code"] == INVALID_CREDENTIALS_ERROR:
             if verbose:
                 _logger.error(
-                    "Invalid Kaggle credentials. You can obtain a Kaggle API token on your [Kaggle settings page](https://www.kaggle.com/settings/account)."
+                    "Invalid Kaggle credentials. You can obtain a Kaggle API token on your [Kaggle API tokens settings page](https://www.kaggle.com/settings/api)."
                 )
         elif verbose:
             _logger.warning("Unable to validate Kaggle credentials at this time.")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -53,7 +53,7 @@ class TestAuth(BaseTestCase):
         captured_output = output_stream.getvalue()
         self.assertEqual(
             captured_output,
-            "Invalid Kaggle credentials. You can obtain a Kaggle API token on your [Kaggle settings page](https://www.kaggle.com/settings/account).\n",
+            "Invalid Kaggle credentials. You can obtain a Kaggle API token on your [Kaggle API tokens settings page](https://www.kaggle.com/settings/api).\n",
         )
 
     def test_capture_logger_output(self) -> None:

--- a/tools/cicd/Dockerfile
+++ b/tools/cicd/Dockerfile
@@ -8,6 +8,6 @@ FROM python:${PYTHON_VERSION}
 
 RUN python -m pip install --upgrade pip
 
-RUN python -m pip install hatch==1.14.0 twine==6.0.1
+RUN python -m pip install hatch==1.16.5 twine==6.0.1
 
 ENTRYPOINT ["hatch"]


### PR DESCRIPTION
Also bump hatch version to fix incompatibility with latest `virtualenv` version (also brings the hatch version inline with kaggle-cli: https://github.com/Kaggle/kaggle-cli/pull/974/).

http://b/502658456