### PR TITLE
Release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next Release
 
+## v1.0.1 (April 28, 2026)
+
+* Fix detail page URL returned. ([#295](https://github.com/Kaggle/kagglehub/pull/295))
+* Update API token page URL. ([#294](https://github.com/Kaggle/kagglehub/pull/294))
+
 ## v1.0.0 (February 11, 2026)
 
 * General Availability release

--- a/src/kagglehub/__init__.py
+++ b/src/kagglehub/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 import kagglehub.logger  # configures the library logger.
 from kagglehub import colab_cache_resolver, http_resolver, kaggle_cache_resolver, registry


### PR DESCRIPTION
Prompt:

> Cut a new release for kagglehub. The version should be 1.0.1. Update the CHANGELOG.md with the latest change from the git history. Follow the same pattern than other entries in the CHANGELOG.md. Ignore typo only commits.

http://b/507122006