### PR TITLE
Parallelize directory uploads

### DIFF
--- a/src/kagglehub/gcs_upload.py
+++ b/src/kagglehub/gcs_upload.py
@@ -229,12 +229,12 @@ def upload_files_and_directories(
                         file_path = os.path.join(root, file)
                         zipf.write(file_path, os.path.relpath(file_path, folder))
 
-            tokens = [
+            archive_tokens = [
                 token
                 for token in [_upload_file(file_path=zip_path, item_type=item_type, quiet=quiet)]
                 if token is not None
             ]
-            return UploadDirectoryInfo(name="archive", files=tokens)
+            return UploadDirectoryInfo(name="archive", files=archive_tokens)
 
     if os.path.isfile(folder):
         root_dict = UploadDirectoryInfo(name="root")
@@ -257,11 +257,11 @@ def upload_files_and_directories(
         if files_to_upload:
             max_workers = min(MAX_PARALLEL_UPLOADS, len(files_to_upload))
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                tokens = executor.map(
+                upload_tokens = executor.map(
                     lambda item: _upload_file(file_path=item[1], item_type=item_type, quiet=quiet),
                     files_to_upload,
                 )
-                for (current_dict, _), token in zip(files_to_upload, tokens, strict=False):
+                for (current_dict, _), token in zip(files_to_upload, upload_tokens, strict=False):
                     if token:
                         current_dict.files.append(token)
 

--- a/src/kagglehub/gcs_upload.py
+++ b/src/kagglehub/gcs_upload.py
@@ -5,6 +5,7 @@ import pathlib
 import time
 import zipfile
 from collections.abc import Iterable, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from tempfile import TemporaryDirectory
 
@@ -24,6 +25,7 @@ MAX_FILES_TO_UPLOAD = 50
 TEMP_ARCHIVE_FILE = "archive.zip"
 MAX_RETRIES = 5
 REQUEST_TIMEOUT = 600
+MAX_PARALLEL_UPLOADS = 8
 
 
 class UploadDirectoryInfo:
@@ -48,6 +50,24 @@ class UploadDirectoryInfo:
         d.directories = [d.to_proto() for d in self.directories]
 
         return d
+
+
+def _get_or_create_upload_directory(root: UploadDirectoryInfo, path: str) -> UploadDirectoryInfo:
+    current = root
+    if path == ".":
+        return current
+
+    for part in path.split(os.sep):
+        for subdir in current.directories:
+            if subdir.name == part:
+                current = subdir
+                break
+        else:
+            new_dir = UploadDirectoryInfo(name=part)
+            current.directories.append(new_dir)
+            current = new_dir
+
+    return current
 
 
 def parse_datetime_string(string: str) -> datetime | str:
@@ -216,37 +236,34 @@ def upload_files_and_directories(
             ]
             return UploadDirectoryInfo(name="archive", files=tokens)
 
-    root_dict = UploadDirectoryInfo(name="root")
     if os.path.isfile(folder):
+        root_dict = UploadDirectoryInfo(name="root")
         # Directly upload the file if the path is a file
         token = _upload_file(file_path=folder, item_type=item_type, quiet=quiet)
         if token:
             root_dict.files.append(token)
     else:
+        root_dict = UploadDirectoryInfo(name="root")
+        files_to_upload = []
         for root, _, files in filtered_walk(base_dir=folder, ignore_patterns=ignore_patterns):
             # Path of the current folder relative to the base folder
             path = os.path.relpath(root, folder)
 
-            # Navigate or create the dictionary path to the current folder
-            current_dict = root_dict
-            if path != ".":
-                for part in path.split(os.sep):
-                    # Find or create the subdirectory in the current dictionary
-                    for subdir in current_dict.directories:
-                        if subdir.name == part:
-                            current_dict = subdir
-                            break
-                    else:
-                        # If the directory is not found, create a new one
-                        new_dir = UploadDirectoryInfo(name=part)
-                        current_dict.directories.append(new_dir)
-                        current_dict = new_dir
-
-            # Add file tokens to the current directory in the dictionary
+            # Build the directory structure before parallel uploads so only the main thread mutates it.
+            current_dict = _get_or_create_upload_directory(root_dict, path)
             for file in files:
-                token = _upload_file(file_path=os.path.join(root, file), item_type=item_type, quiet=quiet)
-                if token:
-                    current_dict.files.append(token)
+                files_to_upload.append((current_dict, os.path.join(root, file)))
+
+        if files_to_upload:
+            max_workers = min(MAX_PARALLEL_UPLOADS, len(files_to_upload))
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                tokens = executor.map(
+                    lambda item: _upload_file(file_path=item[1], item_type=item_type, quiet=quiet),
+                    files_to_upload,
+                )
+                for (current_dict, _), token in zip(files_to_upload, tokens, strict=False):
+                    if token:
+                        current_dict.files.append(token)
 
     return root_dict
 

--- a/tests/test_gcs_upload.py
+++ b/tests/test_gcs_upload.py
@@ -2,8 +2,13 @@
 
 import pathlib
 import tempfile
+import threading
+import time
+from unittest import mock
 
-from kagglehub.gcs_upload import filtered_walk, normalize_patterns
+from kagglesdk.blobs.types.blob_api_service import ApiBlobType
+
+from kagglehub.gcs_upload import filtered_walk, normalize_patterns, upload_files_and_directories
 from tests.fixtures import BaseTestCase
 
 
@@ -61,3 +66,35 @@ class TesModelsHelpers(BaseTestCase):
                 for file_name in file_names:
                     walked_files.append(pathlib.Path(dir_path) / file_name)
             self.assertEqual(set(walked_files), expected_files)
+
+    def test_upload_files_and_directories_uploads_files_in_parallel(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir_p = pathlib.Path(tmp_dir)
+            for file_name in ["a.txt", "b.txt", "c.txt"]:
+                (tmp_dir_p / file_name).touch()
+
+            lock = threading.Lock()
+            active_uploads = 0
+            max_active_uploads = 0
+
+            def fake_upload_file(file_path: str, *, quiet: bool, item_type: ApiBlobType) -> str:
+                nonlocal active_uploads, max_active_uploads
+                _ = quiet, item_type
+                with lock:
+                    active_uploads += 1
+                    max_active_uploads = max(max_active_uploads, active_uploads)
+                time.sleep(0.05)
+                with lock:
+                    active_uploads -= 1
+                return pathlib.Path(file_path).name
+
+            with mock.patch("kagglehub.gcs_upload._upload_file", side_effect=fake_upload_file):
+                upload_dir = upload_files_and_directories(
+                    tmp_dir,
+                    ignore_patterns=[],
+                    item_type=ApiBlobType.DATASET,
+                    quiet=True,
+                )
+
+            self.assertGreater(max_active_uploads, 1)
+            self.assertCountEqual(upload_dir.files, ["a.txt", "b.txt", "c.txt"])


### PR DESCRIPTION
## Summary

This PR parallelizes file uploads for directory uploads while preserving the existing uploaded directory structure.

It keeps the single-file upload path and the archive fallback for more than `MAX_FILES_TO_UPLOAD` files unchanged. For directory uploads below that threshold, files are collected first, the directory tree is built on the main thread, and the actual `_upload_file` calls run through a bounded `ThreadPoolExecutor`.

## Context

This is a small implementation pass for #289, where maintainers noted that parallelized uploads should be feasible. I use Kaggle-style data workflows in medical AI and research tooling, so upload latency for multi-file datasets/models is a practical friction point.

## Validation

- `uv run --with pytest --with flask --with flask-jwt-extended --with pyjwt --with requests --with tqdm --with kagglesdk --with packaging --with pyyaml python -m pytest tests/test_gcs_upload.py tests/test_dataset_upload.py`
- `uv run --with ruff ruff check src/kagglehub/gcs_upload.py tests/test_gcs_upload.py`
- `uv run --with black black --check --diff src/kagglehub/gcs_upload.py tests/test_gcs_upload.py`

Note: I also tried including `tests/test_model_upload.py`, but local collection failed before running tests because the `model_signing` dependency could not import its `blake3` binary module in this environment.

Closes #289